### PR TITLE
Fix README link to project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ yarn add react-static
 # or
 $ npm install react-static --save
 ```
-For more details on migrating an existing app, see the [Project Setup](project-setup) section.
+For more details on migrating an existing app, see the [Project Setup](#project-setup) section.
 
 
 ## CLI


### PR DESCRIPTION
Just the same missing `#` for the `Project setup` section like in #23