### PR TITLE
Add "Charset UTF-8" to HTML-Head in code and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ export default {
   Html: ({ Html, Head, Body, children, siteProps, staticMeta }) => (
     <Html lang="en-US">
       <Head>
+        <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
       <Body>{children}</Body>
@@ -443,6 +444,7 @@ import { Head } from 'react-static'
 export () => (
   <div>
     <Head>
+      <meta charSet="UTF-8" />
       <title>This is my page title!</title>
     </Head>
     <div>

--- a/examples/basic/static.config.js
+++ b/examples/basic/static.config.js
@@ -42,6 +42,7 @@ export default {
       return (
         <Html lang="en-US">
           <Head>
+            <meta charSet="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             <link rel="stylesheet" href="/app.css" />
           </Head>

--- a/examples/custom-routing/static.config.js
+++ b/examples/custom-routing/static.config.js
@@ -34,6 +34,7 @@ export default {
       return (
         <Html lang="en-US">
           <Head>
+            <meta charSet="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             <link rel="stylesheet" href="/app.css" />
           </Head>

--- a/examples/glamorous/static.config.js
+++ b/examples/glamorous/static.config.js
@@ -51,6 +51,7 @@ export default {
       return (
         <Html>
           <Head>
+            <meta charSet="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             <style dangerouslySetInnerHTML={{ __html: css }} />
           </Head>

--- a/examples/styled-components/static.config.js
+++ b/examples/styled-components/static.config.js
@@ -48,6 +48,7 @@ export default {
       return (
         <Html>
           <Head>
+            <meta charSet="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1" />
             {styleTags}
           </Head>

--- a/src/DefaultHtml.js
+++ b/src/DefaultHtml.js
@@ -6,6 +6,7 @@ export default class CustomHtml extends Component {
     return (
       <Html lang="en-US">
         <Head>
+          <meta charSet="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
         </Head>
         <Body>{children}</Body>


### PR DESCRIPTION
`react-static` uses an UTF-8 based magnification process for its build. To ensure those files are interpreted properly by browsers, we should make sure all the HTML-Heads do have the required `<meta charSet="UTF-8" />` included to prevent surprisingly breaking code.

### Changes
- Added `<meta charSet="UTF-8" />` to template and baseline files
- Added `<meta charSet="UTF-8" />` to readme code samples

This closes https://github.com/nozzle/react-static/issues/46