### PR TITLE
Add an option to output the version in the CLI

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,11 +1,17 @@
 import 'babel-register'
 import chalk from 'chalk'
+import fs from 'fs'
 
 require.extensions['.scss'] = () => {}
 require.extensions['.css'] = () => {}
 
 export default function () {
   const cmd = process.argv[2]
+
+  if (['-v', '--version'].indexOf(cmd) !== -1) {
+    const packageJson = JSON.parse(fs.readFileSync(`${__dirname}/../../package.json`, 'utf8'))
+    return console.log(packageJson.version)
+  }
 
   if (cmd === 'start') {
     return require('./start').default()
@@ -26,6 +32,10 @@ Usage: react-static <command>
 - ${chalk.green('create')}  -  create a new project
 - ${chalk.green('start')}  -  start the development server
 - ${chalk.green('build')}  -  build site for production
+
+Options:
+
+    -v, --version output the version number
 `,
   )
 }


### PR DESCRIPTION
This allow to use:

```
$ react-static -v
1.4.1

$ react-static --version
1.4.1
```
