### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postpublish": "git push --tags",
     "test": "eslint src examples"
   },
+  "repository": "nozzle/react-static",
   "devDependencies": {
     "eslint": "^4.3.0",
     "eslint-config-react-tools": "^1.0.6"


### PR DESCRIPTION
This will allow npmjs.com to link to the repo correctly.