### PR TITLE
Update Readme ver to 3.x.x to prevent confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ At [Nozzle.io](https://nozzle.io), we take **SEO, site performance, and user/dev
 - [Nozzle.io](https://nozzle.io)
 
 ## Documentation
-These docs are for version `1.x.x`.
+These docs are for version `3.x.x`.
 
 - [Quick Start](#quick-start)
 - [Installation](#installation)


### PR DESCRIPTION
Readme still states `These docs are for version 1.x.x.`. Change to `3.x.x`. While I think about it, with @calvinrbnspiess changes we need to jump another major version anyhow. And master is not on npm yet? @next points to version 2 alpha.