### PR TITLE
Incl. stage property in rules for prod (undefined)

### DIFF
--- a/src/webpack/webpack.config.prod.js
+++ b/src/webpack/webpack.config.prod.js
@@ -22,7 +22,7 @@ export default function ({ config, isNode }) {
     target: isNode ? 'node' : undefined,
     externals: isNode ? [nodeExternals()] : [],
     module: {
-      rules: rules(),
+      rules: rules({ stage: 'prod' }),
     },
     resolve: {
       modules: [path.resolve(__dirname, '../node_modules'), NODE_MODULES, SRC, DIST],


### PR DESCRIPTION
Loaders, such as `cssLoader` depend on the availability of the stage property to determine if we are in stage === "dev" — it will be undefined otherwise during build.
 
 ### Is this a bug report?
 Yes. For loaders, the stage property needs always to be defined to do build phase testing.
 (write your answer here)
 
 ### Environment

  1. `react-static -v`: master
 2. `node -v`: v8.2.1
 3. `yarn --version`: 1.2.1

 ### Steps to Reproduce
 
 1. Try to build an example from master
 
 ### Expected Behavior
 
Should build.
 
 ### Actual Behavior
 ```bash
=> Bundling App...
TypeError: Cannot read property 'stage' of undefined
    at _default (/Users/worker/development/react-static-typescript-exploration/node_modules/react-static/lib/webpack/rules/cssLoader.js:22:19)
    at _default 
```
![image](https://user-images.githubusercontent.com/2397125/32147495-78ec1b46-bce8-11e7-816a-306d6321740e.png)
