### PR TITLE
Using PORT from process.env instead, if it exists

### DIFF
--- a/src/configServer.js
+++ b/src/configServer.js
@@ -7,8 +7,7 @@ import { findAvailablePort, getConfig } from './utils'
 export async function startConfigServer () {
   const config = getConfig()
   // scan a range
-  let port = await findAvailablePort(8000);
-  port = process.env.PORT || port;
+  const port = process.env.PORT || await findAvailablePort(8000)
   process.env.STATIC_ENDPOINT = `http://127.0.0.1:${port}`
 
   const configApp = express()

--- a/src/configServer.js
+++ b/src/configServer.js
@@ -7,7 +7,8 @@ import { findAvailablePort, getConfig } from './utils'
 export async function startConfigServer () {
   const config = getConfig()
   // scan a range
-  const port = await findAvailablePort(8000)
+  let port = await findAvailablePort(8000);
+  port = process.env.PORT || port;
   process.env.STATIC_ENDPOINT = `http://127.0.0.1:${port}`
 
   const configApp = express()


### PR DESCRIPTION
I'm using hotel to get things running without port/address collision, then I need to pass a port by to get things working as expected while developing my application.

I'm an experienced angular developer in a starting react journey in the company I work for, I learned NextJS and had just found React Static hours ago as a similar (but it really sounds better) SSR framework, by the way.

Thnx, keep rocking. Best regards.