### PR TITLE
FIX TypeScript Example: Babel exclude undefined

### DIFF
--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -53,7 +53,7 @@ export default {
         oneOf: [
           {
             test: /\.(js|jsx|ts|tsx)$/,
-            exclude: config.module.rules[0].exclude,
+            exclude: defaultLoaders.jsLoader.exclude, // as std jsLoader exclude
             use: [
               {
                 loader: 'babel-loader',

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -47,7 +47,7 @@ export async function startDevServer ({ config, port }) {
 
   let first = true
 
-  devCompiler.plugin('invalid', args => {
+  devCompiler.plugin('invalid', () => {
     console.time(chalk.green('=> [\u2713] Build Complete'))
     console.log('=> Rebuilding...')
   })

--- a/src/webpack/rules/cssLoader.js
+++ b/src/webpack/rules/cssLoader.js
@@ -11,6 +11,7 @@ export default function ({ stage }) {
         {
           loader: 'css-loader',
           options: {
+            sourceMap: true,
             importLoaders: 1,
           },
         },
@@ -19,6 +20,7 @@ export default function ({ stage }) {
           options: {
             // Necessary for external CSS imports to work
             // https://github.com/facebookincubator/create-react-app/issues/2677
+            sourceMap: true,
             ident: 'postcss',
             plugins: () => [
               postcssFlexbugsFixes,
@@ -43,6 +45,7 @@ export default function ({ stage }) {
       fallback: {
         loader: 'style-loader',
         options: {
+          sourceMap: false,
           hmr: false,
         },
       },
@@ -52,7 +55,7 @@ export default function ({ stage }) {
           options: {
             importLoaders: 1,
             minimize: true,
-            sourceMap: true,
+            sourceMap: false,
           },
         },
         {
@@ -60,6 +63,7 @@ export default function ({ stage }) {
           options: {
             // Necessary for external CSS imports to work
             // https://github.com/facebookincubator/create-react-app/issues/2677
+            sourceMap: true,
             ident: 'postcss',
             plugins: () => [
               postcssFlexbugsFixes,


### PR DESCRIPTION
Since the format was changed, the exclude is undefined from the rules array. Leading babel to crash by processing `node_modules` and probably the rest of the internet if we let it... 😄