### PR TITLE
Set sourceMap for Style-Loader Instances

### DIFF
--- a/src/webpack.js
+++ b/src/webpack.js
@@ -47,7 +47,7 @@ export async function startDevServer ({ config, port }) {
 
   let first = true
 
-  devCompiler.plugin('invalid', args => {
+  devCompiler.plugin('invalid', () => {
     console.time(chalk.green('=> [\u2713] Build Complete'))
     console.log('=> Rebuilding...')
   })

--- a/src/webpack/rules/cssLoader.js
+++ b/src/webpack/rules/cssLoader.js
@@ -11,6 +11,7 @@ export default function ({ stage }) {
         {
           loader: 'css-loader',
           options: {
+            sourceMap: true,
             importLoaders: 1,
           },
         },
@@ -19,6 +20,7 @@ export default function ({ stage }) {
           options: {
             // Necessary for external CSS imports to work
             // https://github.com/facebookincubator/create-react-app/issues/2677
+            sourceMap: true,
             ident: 'postcss',
             plugins: () => [
               postcssFlexbugsFixes,
@@ -43,6 +45,7 @@ export default function ({ stage }) {
       fallback: {
         loader: 'style-loader',
         options: {
+          sourceMap: false,
           hmr: false,
         },
       },
@@ -52,7 +55,7 @@ export default function ({ stage }) {
           options: {
             importLoaders: 1,
             minimize: true,
-            sourceMap: true,
+            sourceMap: false,
           },
         },
         {
@@ -60,6 +63,7 @@ export default function ({ stage }) {
           options: {
             // Necessary for external CSS imports to work
             // https://github.com/facebookincubator/create-react-app/issues/2677
+            sourceMap: true,
             ident: 'postcss',
             plugins: () => [
               postcssFlexbugsFixes,


### PR DESCRIPTION
Post-Css Loader only has one instance in the webpack build process if it is used multiple times. The options are only set once. To be able to use post-css to its fullest, enable sourceMaps so path-throughs work properly when other style loaders use post-css.

I.e. this is necessary to have a working less loader without dublicating the default cssLoader.