### PR TITLE
Properly set $NODE_ENV using cross-env

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/blank/package.json
+++ b/examples/blank/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/custom-routing/package.json
+++ b/examples/custom-routing/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/dynamic-imports/package.json
+++ b/examples/dynamic-imports/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/glamorous/package.json
+++ b/examples/glamorous/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "glamor": "^2.20.40",
     "glamorous": "^4.9.7",
     "prop-types": "^15.6.0",

--- a/examples/less-antdesign/package.json
+++ b/examples/less-antdesign/package.json
@@ -4,13 +4,14 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "antd": "^2.13.8",
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,12 +4,13 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "react-static start",
-    "build": "react-static build",
+    "start": "cross-env NODE_ENV=development react-static start",
+    "build": "cross-env NODE_ENV=production react-static build",
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "cross-env": "^5.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",


### PR DESCRIPTION
This patch properly sets $NODE_ENV using cross-env to launch react-static with the proper environment variables set. Without this patch, some libraries and utilities, such as react-hot-loader, may leave unnecessary code behind *even when* an optimised production build has taken place.

I tried to see if I could fix this without having to push cross-env into the end user's package.json, but found no solution. There probably is a better solution though, but I'll leave that to the people who are more experienced for JavaScript/Webpack/etc. than me :p

This prevents (albeit minor) problems such as gaearon/react-hot-loader#367.