### PR TITLE
Fix webpack production config destructuring

### DIFF
--- a/src/webpack/webpack.config.prod.js
+++ b/src/webpack/webpack.config.prod.js
@@ -24,7 +24,7 @@ export default function ({ config, isNode }) {
     target: isNode ? 'node' : undefined,
     externals: isNode ? [nodeExternals()] : [],
     module: {
-      rules: rules(config, { stage: 'prod' }),
+      rules: rules({ config, stage: 'prod' }),
     },
     resolve: {
       modules: [path.resolve(__dirname, '../node_modules'), NODE_MODULES, SRC, DIST],


### PR DESCRIPTION
`react-static start` is working great after the path refactor, but `react-static build` crashed because the `config` is not passed properly to the rules function.