### PR TITLE
Ensure Template is a valid React element before trying to render it

### DIFF
--- a/src/static.js
+++ b/src/static.js
@@ -281,7 +281,7 @@ export const prepareRoutes = async config => {
       if (!Template) {
         Template = getTemplateForPath('404')
       }
-      return <Template {...props} />
+      return Template && <Template {...props} />
     }} />
   `
 


### PR DESCRIPTION

 
 ### Is this a bug report?

This bug is detailed in #138. This is the simplest fix I could think of for this bug. It ensures that `Template` is a valid React element before trying to render it and returns `undefined` otherwise.
 
 ### Environment
 
```
-> % react-static -v && node -v && npm -v
4.0.1
v8.3.0
5.3.0
```
 
Operating system: macOS Sierra 10.12.6
 
 ### Steps to Reproduce
 
1. Run `react-static create`
2. Choose `basic` template (it should be a bug with any template, but I haven't confirmed)
3. Remove this from `static.config.js`:
```
{
    is404: true,
    component: 'src/containers/404',
},
```
4. Run `npm run build`
 
 ### Expected Behavior

I expected the `build` command to run without errors
 
 ### Actual Behavior
 
The `build` command threw an error
 