### PR TITLE
Typings for React-Static for full TypeScript Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "react-static",
   "version": "4.0.1",
   "main": "lib/index.js",
+  "types": "src/index.d.ts",
   "license": "MIT",
   "bin": {
     "react-static": "./bin/react-static"
@@ -23,6 +24,9 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@types/react": "^16.0.18",
+    "@types/react-helmet": "^5.0.3",
+    "@types/react-router-dom": "^4.2.0",
     "autoprefixer": "^7.1.5",
     "axios": "^0.16.2",
     "babel-cli": "^6.26.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,32 @@
+// Type definitions for react-static 4.0.1
+// Project: https://github.com/nozzle/react-static
+// Definitions by: D1no <https://github.com/D1no>
+// TypeScript Version: 2.6
+
+/// <reference types="react" />
+
+declare module "react-static" {
+
+  import * as React from "react";
+
+  // Passing on all react-router typings
+  export * from "react-router-dom";
+
+  // Passing on helmet typings as "Head"
+  import * as Helmet from "react-helmet";
+
+  export const Head: Helmet;
+
+  export function getRouteProps(comp: any): any;
+  export function getSiteProps(comp: any): any;
+  export async function prefetch(path: any): any;
+
+  export const Prefetch: React.Component;
+  export const PrefetchWhenSeen: React.Component;
+
+  // Overwriting react-router export as react-static does (no-op)
+  export const BrowserRouter: undefined;
+  export const HashRouter: undefined;
+  export const MemoryRouter: undefined;
+  export const StaticRouter: undefined;
+}


### PR DESCRIPTION
Bundles full TypeScript support. Since React-Static is just a thin layer around existing well typed libraries, we are relaying the type information accordingly (react-router, react-helmet).

This enables TypeScript / WebStorm users to use autocomplete and propper reference to the react-static library.

Since this is a declaration file that doesn't engage with any implementations (just a declaration), this does not effect code in anyway.