### PR TITLE
Unignore typings for production bundles, fixup #140

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,6 +5,7 @@
 /examples/*/dist
 /examples/*/yarn.lock
 /src
+!/src/index.d.ts
 
 # misc
 .DS_Store


### PR DESCRIPTION
In #140 the project added TypeScript typings (yeay!). But after installing 4.1.0 I am unable to find the typings file in my `node_modules`, because [they are ignored as a part of `src`](https://github.com/nozzle/react-static/blob/81fa589470afe84a4a623a4c97f505da86705f7f/.npmignore#L7).

@D1no @tannerlinsley 