### PR TITLE
Make template imports dynamic

### DIFF
--- a/src/static.js
+++ b/src/static.js
@@ -227,7 +227,7 @@ export const prepareRoutes = async config => {
   })
 
   const templateImports = templates
-    .map(template => `import ${template.replace(/[^a-zA-Z]/g, '_')} from '../${template}'`)
+    .map(template => `import ${template.replace(/[^a-zA-Z]/g, '_')} from '${path.resolve(config.paths.ROOT, template)}'`)
     .join('\n')
 
   const templateMap = `const templateMap = {


### PR DESCRIPTION
The template imports are currently hardcoded to be imported one folder up. This PR makes the imports dynamic, so that the potential `paths` given by the user in `static.config.js` can be general. Closes https://github.com/nozzle/react-static/issues/154.