### PR TITLE
Add .md & .yaml to Extension whitelist

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -21,6 +21,8 @@ const ignoredExtensions = [
   'ogg',
   'mp3',
   'wav',
+  'md',
+  'yaml'
 ]
 ignoredExtensions.forEach(ext => {
   require.extensions[`.${ext}`] = () => {}


### PR DESCRIPTION
Extensions not getting through to webpack as they are blocked by the Babel preprocessor.
 
 ### Is this a bug report?
 
Yes 

See: https://github.com/nozzle/react-static/issues/171