### PR TITLE
Escape script tags in routeData (#178)

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -22,7 +22,7 @@ const ignoredExtensions = [
   'mp3',
   'wav',
   'md',
-  'yaml'
+  'yaml',
 ]
 ignoredExtensions.forEach(ext => {
   require.extensions[`.${ext}`] = () => {}

--- a/src/static.js
+++ b/src/static.js
@@ -139,7 +139,7 @@ export const exportRoutes = async ({ config }) => {
           path: route.path,
           initialProps,
           siteProps,
-        })};
+        }).replace(/<(\/)?(script)/ig, '<"+"$1$2')};
                 window.__routesList = ${JSON.stringify(routesList)};
               `,
             }}


### PR DESCRIPTION
 ### Is this a bug report?
 
Yes

See #178 

Any version
 
 ### Steps to Reproduce
  
 1. Create a route prop with a string containing `<script></script>`
 2. Build the static site
 3. Open the static page in any browser
 
 
 ### Expected Behavior
 
The page would render correctly
 
 
 ### Actual Behavior
 
 The browser stops parsing the route props generated by react-static as soon as it encounters the character sequence `</script>`, causing the rest of the script to incorrectly be interpreted as document markup.


### The solution

Break the generated JSON string and rejoin with `+` operator to avoid the browser parsing it as a closing script tag
