### PR TITLE
Make the getRoutes url absolute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ if (typeof document !== 'undefined') {
   routesPromise = (async () => {
     let res
     if (process.env.NODE_ENV === 'development') {
-      res = await axios.get('__react-static__/getroutes')
+      res = await axios.get('/__react-static__/getRoutes')
       return res.data
     }
     return window.__routesList


### PR DESCRIPTION
 ### Is this a bug report?
 
Yes
 
 ### Environment
 
 1. `react-static -v`: 4.2.3
 2. `node -v`: 8.9.0
 3. `yarn --version`: 1.3.2
 
 ### Steps to Reproduce
 
 1. Create a new `basic` example with `react-static create`.
 2. Start the dev server with `yarn start` and navigate to `http://localhost:3000/blog/post/1/` and refresh.
 
 ### Expected Behavior

Gets the routes from `/__react-static__/getRoutes` 
 
 ### Actual Behavior
 
Gets the routes from `blog/post/1/__react-static__/getroutes`

### Closes
https://github.com/nozzle/react-static/issues/176