### PR TITLE
Set NODE_ENV on start/build, use distPath for html template

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -37,10 +37,12 @@ export default function () {
   }
 
   if (cmd === 'start') {
+    process.env.NODE_ENV = 'development'
     return require('./start').default()
   }
 
   if (cmd === 'build') {
+    process.env.NODE_ENV = 'production'
     return require('./build').default()
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,18 +52,18 @@ export const getConfig = () => {
   const resolvePath = relativePath => path.resolve(path.join(ROOT, relativePath))
 
   // Resolve all paths
+  const distPath = process.env.NODE_ENV === 'development'
+    ? resolvePath(config.paths.devDist || config.paths.dist)
+    : resolvePath(config.paths.dist)
   const paths = {
     ROOT,
     LOCAL_NODE_MODULES: path.resolve(__dirname, '../node_modules'),
     SRC: resolvePath(config.paths.src),
-    DIST:
-      process.env.NODE_ENV === 'development'
-        ? resolvePath(config.paths.devDist || config.paths.dist)
-        : resolvePath(config.paths.dist),
+    DIST: distPath,
     PUBLIC: resolvePath(config.paths.public),
     NODE_MODULES: resolvePath('node_modules'),
     PACKAGE: resolvePath('package.json'),
-    HTML_TEMPLATE: path.join(resolvePath(config.paths.dist), 'index.html'),
+    HTML_TEMPLATE: path.join(distPath, 'index.html'),
   }
 
   const siteRoot = config.siteRoot ? config.siteRoot.replace(/\/{0,}$/g, '') : null


### PR DESCRIPTION
### Is this a bug report?
 
Yes
 
 ### Environment
 
 1. `react-static -v`: 4.3.0
 2. `node -v`: 8.9.0
 3. `yarn --version`: 1.3.2
 
 ### Steps to Reproduce
 
 1. Add `paths: { devDist: 'local' }` to `static.config.js`
 2. Start the dev server with `yarn start`
 
 ### Expected Behavior

Creates a `local` folder and uses that instead of `dist` 
 
 ### Actual Behavior
 
Uses the `dist` folder
 
### Probable explanation
`process.env.NODE_ENV` is not set properly, so the `process.env.NODE_ENV === 'development'` check when giving `paths.DIST` a value is not working as intended. Explicitly giving it a value on `start` and `build` works great.

The `HTML_TEMPLATE` path also had to be made dynamic, and all the files were now created in the correct folder.

### Closes
https://github.com/nozzle/react-static/issues/181