### PR TITLE
Fix path for imports on Windows

### DIFF
--- a/src/static.js
+++ b/src/static.js
@@ -242,6 +242,7 @@ export const prepareRoutes = async config => {
         )}'`,
     )
     .join('\n')
+    .replace(/\\/g, '/')
 
   const templateMap = `const templateMap = {
     ${templates


### PR DESCRIPTION
<!--
   PLEASE READ THE FIRST SECTION :-)
 -->
 
 ### Is this a bug report?
 
Fixes https://github.com/nozzle/react-static/issues/184

 ### Environment
 
 <!--
   Please fill in all the relevant fields by running these commands in terminal.
 -->
 
 1. `react-static -v`: 4.3.2
 2. `node -v`: 9.2.0
 3. `yarn --version or npm -v`: yarn 1.3.2
 
 Then, specify:
 
 1. Operating system: Windows 10
 2. Browser and version (if relevant):
 
 
 ### Steps to Reproduce
 
 <!--
   How would you describe your issue to someone who doesn’t know you or your project?
   Try to write a sequence of steps that anybody can repeat to see the issue.
 -->
 
 (Write your steps here:)
 
 1. Run example on Windows (I used the styled-components one)
 
 ### Expected Behavior
 
Run without error. 

### Cause of issue

[path.resolve(config.paths.ROOT, template),](https://github.com/nozzle/react-static/blob/da68e23609742a38cf22b92eef07d343f2af44be/src/static.js#L241) is returning OS specific paths. On Windows they contain backslashes instead of slashes. To fix this, all backslashes need to be replaced with slashes, because even on Windows the import paths have forward slashes.

`


 
