### PR TITLE
less-antdesign: Fix antd scope in package.json

### DIFF
--- a/examples/less-antdesign/package.json
+++ b/examples/less-antdesign/package.json
@@ -9,7 +9,7 @@
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
-    "antd": "^next",
+    "antd": "next",
     "axios": "^0.17.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",


### PR DESCRIPTION
The `^` does not work with npm version tags. This fixes it.

 ### Is this a bug report?
 
![screen shot 2017-11-26 at 19 11 43](https://user-images.githubusercontent.com/2397125/33243011-e6b5bc12-d2dd-11e7-998f-1dd26ec2ff62.png)
