### PR TITLE
Add .esm-cache to the .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.esm-cache
+
 *.log
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
.esm-cache is a huge folder (~25mb) which results in the react-static package being ~35mb.

Is this folder necessary for the published package?

It is already being ignored via [.gitignore](https://github.com/nozzle/react-static/blob/master/.gitignore#L20). 

 ### Environment
 
 1. `react-static -v`: 4.3.4
 2. `node -v`: 8.9.1
 3. `yarn --version or npm -v`: yarn 1.3.2
 4. Operating system: macOS
 
 ### Actual Behavior
 
![image](https://user-images.githubusercontent.com/7423098/33510431-85e3b50e-d6d1-11e7-8013-eb3af77721e4.png)

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package