### PR TITLE
Use ReactDOM.render instead of ReactDOM.hydrate in dev

### DIFF
--- a/examples/apollo-redux/src/index.js
+++ b/examples/apollo-redux/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/apollo/src/index.js
+++ b/examples/apollo/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/blank/src/index.js
+++ b/examples/blank/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/cordova/src/index.js
+++ b/examples/cordova/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/custom-routing/src/index.js
+++ b/examples/custom-routing/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/dynamic-imports/src/index.js
+++ b/examples/dynamic-imports/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/glamorous/src/index.js
+++ b/examples/glamorous/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/less-antdesign/src/index.js
+++ b/examples/less-antdesign/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/redux/src/index.js
+++ b/examples/redux/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/styled-components/src/index.js
+++ b/examples/styled-components/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,

--- a/examples/typescript/src/index.js
+++ b/examples/typescript/src/index.js
@@ -10,8 +10,9 @@ export default App
 
 // Render your app
 if (typeof document !== 'undefined') {
+  const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate
   const render = Comp => {
-    ReactDOM.hydrate(
+    renderMethod(
       <AppContainer>
         <Comp />
       </AppContainer>,


### PR DESCRIPTION
This PR changes `ReactDOM.hydrate` to `ReactDOM.render` in dev mode in all the examples, so the user doesn't get `Warning: Expected server HTML to contain a matching <div> in <div>.`, as outlined by @mattyfresh in https://github.com/nozzle/react-static/issues/144.