### PR TITLE
revert dist path changes

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -37,12 +37,10 @@ export default function () {
   }
 
   if (cmd === 'start') {
-    process.env.NODE_ENV = 'development'
     return require('./start').default()
   }
 
   if (cmd === 'build') {
-    process.env.NODE_ENV = 'production'
     return require('./build').default()
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,18 +52,18 @@ export const getConfig = () => {
   const resolvePath = relativePath => path.resolve(path.join(ROOT, relativePath))
 
   // Resolve all paths
-  const distPath = process.env.NODE_ENV === 'development'
-    ? resolvePath(config.paths.devDist || config.paths.dist)
-    : resolvePath(config.paths.dist)
   const paths = {
     ROOT,
     LOCAL_NODE_MODULES: path.resolve(__dirname, '../node_modules'),
     SRC: resolvePath(config.paths.src),
-    DIST: distPath,
+    DIST:
+      process.env.NODE_ENV === 'development'
+        ? resolvePath(config.paths.devDist || config.paths.dist)
+        : resolvePath(config.paths.dist),
     PUBLIC: resolvePath(config.paths.public),
     NODE_MODULES: resolvePath('node_modules'),
     PACKAGE: resolvePath('package.json'),
-    HTML_TEMPLATE: path.join(distPath, 'index.html'),
+    HTML_TEMPLATE: path.join(resolvePath(config.paths.dist), 'index.html'),
   }
 
   const siteRoot = config.siteRoot ? config.siteRoot.replace(/\/{0,}$/g, '') : null


### PR DESCRIPTION
Reverted the dist path changes. The old method prior to 4.3.1 worked fine just had some annoyances when utilizing https on port 443 but was more usable than forcing node environment.