### PR TITLE
Update graphql-request example to use react-markdown

### DIFF
--- a/examples/graphql-request/package.json
+++ b/examples/graphql-request/package.json
@@ -12,6 +12,7 @@
     "graphql-request": "^1.4.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-markdown": "^3.1.0",
     "react-router": "^4.2.0",
     "react-static": "^4.3.4"
   },

--- a/examples/graphql-request/src/pages/Post.js
+++ b/examples/graphql-request/src/pages/Post.js
@@ -12,7 +12,7 @@ export default getRouteProps(({ post }) => (
       />
     </div>
     <Markdown
-      content={post.content}
+      source={post.content}
       escapeHtml={false}
     />
   </article>

--- a/examples/graphql-request/src/pages/Post.js
+++ b/examples/graphql-request/src/pages/Post.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { getRouteProps } from 'react-static'
+import Markdown from 'react-markdown'
 
 export default getRouteProps(({ post }) => (
   <article>
@@ -10,12 +11,9 @@ export default getRouteProps(({ post }) => (
         src={`https://media.graphcms.com/resize=w:650,h:366,fit:crop/${post.coverImage.handle}`}
       />
     </div>
-    {/*
-      dangerouslySetInnerHTML is here to parse a markdown field from GraphCMS.
-      The field contains a string with HTML tags as GraphCMS already does the markdown parsing.
-      If you want to avoid dangerouslySetInnerHTML in your project you can use any html/markdown
-      parsing plugin for React like https://github.com/rexxars/react-markdown
-    */}
-    <div dangerouslySetInnerHTML={{ __html: post.content }} /> {/* eslint react/no-danger: 0 */}
+    <Markdown
+      content={post.content}
+      escapeHtml={false}
+    />
   </article>
 ))


### PR DESCRIPTION
So it turns out the `dangerouslySetInnerHTML` was working because the post's `content` field was rich text. It has been converted to markdown in default `Blog` template and in the project that the example is using atm.

I've added `react-markdown` to the example and removed `dangerouslySetInnerHTML` to reflect the rich text -> markdown change.