### PR TITLE
Pass additional CLI arguments through to getSiteProps()

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -5,7 +5,7 @@ import { exportRoutes, buildXMLandRSS, prepareRoutes } from '../static'
 import { buildProductionBundles } from '../webpack'
 import { getConfig, copyPublicFolder } from '../utils'
 
-export default async () => {
+export default async (cliArguments) => {
   try {
     const config = getConfig()
     await fs.remove(config.paths.DIST)
@@ -39,6 +39,7 @@ export default async () => {
     await exportRoutes({
       config,
       clientStats,
+      cliArguments,
     })
     await buildXMLandRSS({ config })
     console.timeEnd(chalk.green('=> [\u2713] Routes Exported'))

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -5,7 +5,7 @@ import { exportRoutes, buildXMLandRSS, prepareRoutes } from '../static'
 import { buildProductionBundles } from '../webpack'
 import { getConfig, copyPublicFolder } from '../utils'
 
-export default async (cliArguments) => {
+export default async cliArguments => {
   try {
     const config = getConfig()
     await fs.remove(config.paths.DIST)

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -30,6 +30,7 @@ ignoredExtensions.forEach(ext => {
 
 export default function () {
   const cmd = process.argv[2]
+  const cliArguments = process.argv.slice(3)
 
   if (['-v', '--version'].indexOf(cmd) !== -1) {
     const packageJson = JSON.parse(fs.readFileSync(`${__dirname}/../../package.json`, 'utf8'))
@@ -41,7 +42,7 @@ export default function () {
       process.env.NODE_ENV = 'development'
     }
     process.env.REACT_STATIC_ENV = 'development'
-    return require('./start').default()
+    return require('./start').default(cliArguments)
   }
 
   if (cmd === 'build') {
@@ -49,7 +50,7 @@ export default function () {
       process.env.NODE_ENV = 'production'
     }
     process.env.REACT_STATIC_ENV = 'production'
-    return require('./build').default()
+    return require('./build').default(cliArguments)
   }
 
   if (cmd === 'create') {

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -7,7 +7,7 @@ import { startDevServer } from '../webpack'
 import { getConfig, copyPublicFolder, createIndexFilePlaceholder } from '../utils'
 //
 
-export default async (cliArguments) => {
+export default async cliArguments => {
   try {
     // Get the config
     const config = getConfig()

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -7,7 +7,7 @@ import { startDevServer } from '../webpack'
 import { getConfig, copyPublicFolder, createIndexFilePlaceholder } from '../utils'
 //
 
-export default async () => {
+export default async (cliArguments) => {
   try {
     // Get the config
     const config = getConfig()
@@ -16,7 +16,7 @@ export default async () => {
     await fs.remove(config.paths.DIST)
 
     // Get the site props
-    const siteProps = await config.getSiteProps({ dev: true })
+    const siteProps = await config.getSiteProps({ dev: true, cliArguments })
 
     // Resolve the base HTML template
     const Component = config.Document || DefaultDocument

--- a/src/static.js
+++ b/src/static.js
@@ -13,7 +13,7 @@ import shorthash from 'shorthash'
 import { DefaultDocument } from './RootComponents'
 
 // Exporting route HTML and JSON happens here. It's a big one.
-export const exportRoutes = async ({ config, clientStats }) => {
+export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
   // Use the node version of the app created with webpack
   const appJsPath = glob.sync(path.resolve(config.paths.DIST, 'app!(.static).*.js'))[0]
   const appJs = appJsPath.split('/').pop()
@@ -22,7 +22,7 @@ export const exportRoutes = async ({ config, clientStats }) => {
 
   const DocumentTemplate = config.Document || DefaultDocument
 
-  const siteProps = await config.getSiteProps({ dev: false })
+  const siteProps = await config.getSiteProps({ dev: false, cliArguments })
 
   const seenProps = new Map()
   const sharedProps = new Map()


### PR DESCRIPTION
Allows configuring builds from the command line by forwarding all additional CLI arguments to `getSiteProps()`. 

The parameter to `getSiteProps` is an object that now has a `cliArguments` property which is an array of strings that followed the command `build|serve|create` on the command line