### PR TITLE
Allow hooking into the beginning of the build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,12 +243,15 @@ export default {
     public: 'public' // The public directory (files copied to dist during build)
   },
 
-  // onStart and onBuild are utility hooks that run when the dev server starts up successfully
-  // and after a build has completed.
-  // onStart provides you with the final, READONLY devServer config object for convenience.
-  // onBuild currently does NOT provide any parameters
+  // onStart runs when the dev server starts up successfully
+  // and provides you with the final, READONLY devServer config object for convenience.
   onStart: ({ devServerConfig }) => {...},
-  onBuild: async () => {...},
+
+  // beforeBuild runs before the build starts and provides you with the config object.
+  beforeBuild: async ({ config }) => {...},
+
+  // onBuild runs after the build finishes and provides you with the config object.
+  onBuild: async ({ config }) => {...},
 
   // Optional. Set to true to serve the bundle analyzer on a production build.
   bundleAnalyzer: false,

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -11,7 +11,11 @@ export default async cliArguments => {
     await fs.remove(config.paths.DIST)
 
     console.log('')
-    console.time('=> Site is ready for production!')
+    console.time('=> Preparing site for production!')
+
+    if (config.beforeBuild) {
+      await config.beforeBuild({ config })
+    }
 
     console.log('=> Copying public directory...')
     console.time(chalk.green('=> [\u2713] Public directory copied'))


### PR DESCRIPTION
This PR adds an async function that is called at the beginning of the build process. 

We are using this hook to fetch data that is used during the build process. Is this the right place to handle this?