### PR TITLE
Add shouldPrefetch() method to avoid setting loading state unnecessarily

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,14 @@ function isPrefetched (path) {
   }
 }
 
+async function shouldPrefetch (path) {
+  path = cleanPath(path)
+  // Get route info so we can check if path has any data
+  const routes = await getRouteInfo()
+  // Returns true if data exists for path
+  return routes[path] !== undefined
+}
+
 export async function prefetch (path) {
   path = cleanPath(path)
 

--- a/src/index.js
+++ b/src/index.js
@@ -517,7 +517,7 @@ export class Router extends Component {
         const originalMethod = resolvedHistory[method]
         resolvedHistory[method] = async (...args) => {
           const path = typeof args[0] === 'string' ? args[0] : args[0].path + args[0].search
-          if (!isPrefetched(path)) {
+          if (await shouldPrefetch(path) && !isPrefetched(path)) {
             setLoading(true)
             await prefetch(path)
             setLoading(false)


### PR DESCRIPTION
Adds `shouldPrefetch` function that is intended to be used in conjunction with `isPrefetched` when firing wrapped routing methods.

This avoids calling `setLoading(true)` and `setLoading(false)` and subsequently calling any Router subscribers if there is no data to be loaded for requested path.

The issue I was having with the current logic implementation was that routes that do not have any props defined within `static.config.js`, regardless of site props being used, would still trigger the Router loading subscribers. 

If you are using these subscribers to show a loading overlay, for example, you can see this flash momentarily as the state changes. As no request is actually fired for routes with no data, I presume the loading state should not be set?

Routes with props/using `getRouteProps` work as expected - only triggering the loading state once, as they are cached within the `pathProps` object.

I _think_ this is a viable way to fix this problem - however, if you think this is incorrect, or this functions like this for a reason I may have missed, then please advise!

(P.S Props for the amazing work on this project, it's ace 👍 ).