### PR TITLE
Prefetch when route for getRouteProps component change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -240,21 +240,31 @@ export function getRouteProps (Comp) {
     state = {
       loaded: false,
     }
-    async componentWillMount () {
+    componentWillMount () {
       if (process.env.REACT_STATIC_ENV === 'development') {
-        const { pathname, search } = this.context.router.route.location
-        const path = pathJoin(`${pathname}${search}`)
-        await prefetch(path)
-        if (this.unmounting) {
-          return
+        this.loadRouteProps()
+      }
+    }
+    componentWillReceiveProps (nextProps) {
+      if (process.env.REACT_STATIC_ENV === 'development') {
+        if (this.props.match.url !== nextProps.match.url) {
+          this.setState({ loaded: false }, this.loadRouteProps)
         }
-        this.setState({
-          loaded: true,
-        })
       }
     }
     componentWillUnmount () {
       this.unmounting = true
+    }
+    loadRouteProps = async () => {
+      const { pathname, search } = this.context.router.route.location
+      const path = pathJoin(`${pathname}${search}`)
+      await prefetch(path)
+      if (this.unmounting) {
+        return
+      }
+      this.setState({
+        loaded: true,
+      })
     }
     render () {
       const { pathname, search } = this.context.router.route.location


### PR DESCRIPTION
 ### Is this a bug report?
 
Yes. https://github.com/nozzle/react-static/issues/254
 
 ### Environment
 
 1. `react-static -v`: 4.7.1
 2. `node -v`: 8.9.0
 3. `yarn --version`: 1.3.2
 ### Steps to Reproduce
 
 1. Create a new `basic` example with `react-static create`
 2. Use the same component with the `getRouteProps` HOC for more than one route (like e.g. https://github.com/nozzle/react-static/issues/254)
 3. Start the dev server and navigate between these routes that have the same component
 
 ### Expected Behavior
Should get the route props when the route change

 ### Actual Behavior
The loading spinner appears and `Warning: getRouteProps could not find any props for route: /<your_route_with_the_same_component>.` is shown in the console.
There is currently no logic to fetch the route props when the `match` changes for the same component. This results in `loaded` being set to `true`, but `initialProps` not being set for this new route, so the loading spinner is shown indefinitely. 
