### PR TITLE
Fix Node 6 support

### DIFF
--- a/src/static.js
+++ b/src/static.js
@@ -37,7 +37,7 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
       }
 
       // Loop through the props
-      Object.values(route.initialProps).forEach(prop => {
+      Object.keys(route.initialProps).map(k => route.initialProps[k]).forEach(prop => {
         // Have we seen this prop before?
         if (seenProps.get(prop)) {
           // Only cache each shared prop once


### PR DESCRIPTION
react-static 4.7.0...4.8.2 are still broken in Node 6, with what we discussed in #256 is BC breakage. This fixes it.