### PR TITLE
Added note about ReactDOM render method when using preact

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ export default {
 }
 ```
 
+**Note**: If updating a project not originally based on the `preact` template, you will need to update the render method of your app to always use `ReactDOM.render` and not `ReactDOM.hydrate`. [See the preact template for an example of this](https://github.com/nozzle/react-static/blob/master/examples/preact/src/index.js#L14)
+
 **Important**
 Due to the complexity of maintaining a fully tooled development experience, React is still used in development mode if `preact` is set to `true`. This ensures that stable hot-reloading tooling, dev tools, ect. are used. This is by no means permanent though! If you know what it takes to emulate React Static's development environment using Preact tooling, please submit a PR!
 


### PR DESCRIPTION
Added a **Note** to the README about not using `ReactDOM.hydrate` when using `preact: true` config option.

This stumped me for a bit until I saw the [note in the CHANGELOG](https://github.com/nozzle/react-static/blob/master/CHANGELOG.md#480) about making this switch and then looking at the `preact` example.

I thought this should be added to the README as it may catch out other people too, particularly those who are adding the `preact` option to and existing react-static app based on a different template.