### PR TITLE
Use slash paths for templates consistently across OSes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepublishOnly": "yarn build",
     "postpublish": "git push --tags",
     "test": "eslint src examples test && yarn run test-sample-build",
-    "test-sample-build": "yarn build && (cd test/minimal-website && ../../bin/react-static build)",
+    "test-sample-build":
+      "yarn build && (cd test/minimal-website && ../../bin/react-static build)",
     "test-webpack": "jest"
   },
   "repository": "nozzle/react-static",
@@ -77,6 +78,7 @@
     "react-router-dom": "^4.2.2",
     "react-universal-component": "^2.8.1",
     "shorthash": "^0.0.2",
+    "slash": "^1.0.0",
     "style-loader": "^0.19.0",
     "swimmer": "^1.1.1",
     "url-loader": "^0.6.1",
@@ -85,5 +87,9 @@
     "webpack-dev-server": "^2.8.2",
     "webpack-flush-chunks": "^1.2.3",
     "webpack-node-externals": "^1.6.0"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true
   }
 }

--- a/src/static.js
+++ b/src/static.js
@@ -10,13 +10,16 @@ import Helmet from 'react-helmet'
 import shorthash from 'shorthash'
 import { ReportChunks } from 'react-universal-component'
 import flushChunks from 'webpack-flush-chunks'
+import slash from 'slash'
 //
 import { DefaultDocument } from './RootComponents'
 
 // Exporting route HTML and JSON happens here. It's a big one.
 export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
   // Use the node version of the app created with webpack
-  const Comp = require(glob.sync(path.resolve(config.paths.DIST, 'static.*.js'))[0]).default
+  const Comp = require(glob.sync(
+    path.resolve(config.paths.DIST, 'static.*.js')
+  )[0]).default
 
   const DocumentTemplate = config.Document || DefaultDocument
 
@@ -28,7 +31,8 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
   await Promise.all(
     config.routes.map(async route => {
       // Fetch initialProps from each route
-      route.initialProps = !!route.getProps && (await route.getProps({ route, dev: false }))
+      route.initialProps =
+        !!route.getProps && (await route.getProps({ route, dev: false }))
 
       if (!route.initialProps) {
         route.initialProps = {}
@@ -120,7 +124,7 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
           siteProps: PropTypes.object,
           staticURL: PropTypes.string
         }
-        getChildContext () {
+        getChildContext() {
           return {
             propsMap: route.propsMap,
             initialProps: route.initialProps,
@@ -128,7 +132,7 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
             staticURL
           }
         }
-        render () {
+        render() {
           return this.props.children
         }
       }
@@ -211,12 +215,23 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
             {head.base}
             {showHelmetTitle && head.title}
             {head.meta}
-            <link rel="preload" as="script" href={`${config.publicPath}routeInfo.js`} />
+            <link
+              rel="preload"
+              as="script"
+              href={`${config.publicPath}routeInfo.js`}
+            />
             {clientScripts.map(script => (
-              <link rel="preload" as="script" href={`${config.publicPath}${script}`} />
+              <link
+                rel="preload"
+                as="script"
+                href={`${config.publicPath}${script}`}
+              />
             ))}
             {clientStyleSheets.map(styleSheet => (
-              <link rel="stylesheet" href={`${config.publicPath}${styleSheet}`} />
+              <link
+                rel="stylesheet"
+                href={`${config.publicPath}${styleSheet}`}
+              />
             ))}
             {head.link}
             {head.noscript}
@@ -237,15 +252,19 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
             dangerouslySetInnerHTML={{
               __html: `
                 window.__routeData = ${JSON.stringify({
-          path: route.path,
-          propsMap: route.propsMap,
-          initialProps: route.initialProps,
-          siteProps
-        }).replace(/<(\/)?(script)/gi, '<"+"$1$2')};`
+                  path: route.path,
+                  propsMap: route.propsMap,
+                  initialProps: route.initialProps,
+                  siteProps
+                }).replace(/<(\/)?(script)/gi, '<"+"$1$2')};`
             }}
           />
           {clientScripts.map(script => (
-            <script defer type="text/javascript" src={`${config.publicPath}${script}`} />
+            <script
+              defer
+              type="text/javascript"
+              src={`${config.publicPath}${script}`}
+            />
           ))}
         </body>
       )
@@ -279,7 +298,7 @@ export const exportRoutes = async ({ config, clientStats, cliArguments }) => {
   )
 }
 
-export async function buildXMLandRSS ({ config }) {
+export async function buildXMLandRSS({ config }) {
   if (!config.siteRoot) {
     console.log(`
       => Warning: No 'siteRoot' defined in 'static.config.js'!
@@ -298,7 +317,7 @@ export async function buildXMLandRSS ({ config }) {
 
   await fs.writeFile(path.join(config.paths.DIST, 'sitemap.xml'), xml)
 
-  function generateXML ({ routes }) {
+  function generateXML({ routes }) {
     let xml =
       '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
     routes.forEach(route => {
@@ -307,7 +326,9 @@ export async function buildXMLandRSS ({ config }) {
       }
       xml += '<url>'
       xml += `<loc>${`${route.permalink}/`.replace(/\/{1,}$/gm, '/')}</loc>`
-      xml += route.lastModified ? `<lastmod>${route.lastModified}</lastmod>` : ''
+      xml += route.lastModified
+        ? `<lastmod>${route.lastModified}</lastmod>`
+        : ''
       xml += route.priority ? `<priority>${route.priority}</priority>` : ''
       xml += '</url>'
     })
@@ -328,7 +349,8 @@ export const prepareRoutes = async config => {
 
   const tree = {}
   routes.forEach(route => {
-    const parts = route.path === '/' ? ['/'] : route.path.split('/').filter(d => d)
+    const parts =
+      route.path === '/' ? ['/'] : route.path.split('/').filter(d => d)
     let cursor = tree
     parts.forEach((part, partIndex) => {
       const isLeaf = parts.length === partIndex + 1
@@ -359,14 +381,16 @@ export const prepareRoutes = async config => {
     }
 
     ${templates
-    .map(
-      (template, index) =>
-        `const t_${index} = universal(import('${path.relative(
+      .map((template, index) => {
+        const templatePath = path.relative(
           config.paths.DIST,
           path.resolve(config.paths.ROOT, template)
+        )
+        return `const t_${index} = universal(import('${slash(
+          templatePath
         )}'), universalOptions)`
-    )
-    .join('\n')}
+      })
+      .join('\n')}
 
     // Template Map
     const templateMap = {
@@ -375,8 +399,8 @@ export const prepareRoutes = async config => {
 
     // Template Tree
     const templateTree = ${JSON.stringify(tree)
-    .replace(/"(\w)":/gm, '$1:')
-    .replace(/template: '(.+)'/gm, 'template: $1')}
+      .replace(/"(\w)":/gm, '$1:')
+      .replace(/template: '(.+)'/gm, 'template: $1')}
 
     // Get template for given path
     const getComponentForPath = path => {
@@ -429,7 +453,10 @@ export const prepareRoutes = async config => {
     }
   `
 
-  const dynamicRoutesPath = path.resolve(config.paths.DIST, 'react-static-routes.js')
+  const dynamicRoutesPath = path.resolve(
+    config.paths.DIST,
+    'react-static-routes.js'
+  )
   await fs.remove(dynamicRoutesPath)
   await fs.writeFile(dynamicRoutesPath, file)
 


### PR DESCRIPTION
### Environment

1. `react-static -v`: 4.9.0-beta.5
2. `node -v`: v8.9.4
3. `yarn --version`: 1.3.2

Then, specify:
 
1. Operating system: Windows
 
### Expected Behavior

The build should produce a `react-static-routes.js` file containing a path to each template that works across operating systems.

### Actual Behavior
 
Error after building:

```bash
./dist/react-static-routes.js
Module not found: Can't resolve '..srcpagesHome' in 'C:\path\to\project\dist'
```