### PR TITLE
Fix link to staticconfig.js documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you read these docs on `npmjs.com`, they correspond to the [published version
   - [`react-static start`](#react-static-start)
   - [`react-static build`](#react-static-build)
 - [Project Setup](#project-setup)
-- [Configuration (`static.config.js`)](#configuration-staticconfigjs)
+- [Configuration (`static.config.js`)](#configuration--staticconfigjs-)
 - [Components & Tools](#components--tools)
   - [`<Router>`](#router)
   - [`<Routes>`](#routes)


### PR DESCRIPTION
 
 ### Is this a bug report?
Yes


 ### Environment
 
The environment details are irrelevant and therefore I'm leaving them blank
 
 1. `react-static -v`: 
 2. `node -v`:
 3. `yarn --version or npm -v`:
 
 Then, specify:
 
 1. Operating system:
 2. Browser and version (if relevant):
 
 
 ### Steps to Reproduce
 
 1. Open the documentation `https://www.npmjs.com/package/react-static`
 2. Click on `Configuration (static.config.js)` under documentation
 3. Nothing happens
 
 
 ### Expected Behavior
 
It should move to the `Configuration (static.config.js)` section on the page
 
 ### Actual Behavior

Nothing Happens when clicked on that link (the Url changes to something but the page does not scroll to the right element)

When clicked on the following `Configuration (static.config.js)`
![screen shot 2018-01-28 at 11 23 12 pm](https://user-images.githubusercontent.com/1362028/35485318-ee6ffbde-0483-11e8-957c-275048189447.png)

Should move to the following `Configuration (static.config.js)`
![screen shot 2018-01-28 at 11 23 28 pm](https://user-images.githubusercontent.com/1362028/35485326-0f9eb570-0484-11e8-93f6-67934b8508b3.png)
 
 
 ### Reproducible Demo
 
The above screenshots should be clear enough