### PR TITLE
API Reference: Remove duplicate devServer

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -309,21 +309,6 @@ export default {
 }
 ```
 
-**Using Custom devServer properties**
-
-This project uses webpack-dev-server. The `devServer` config object can be used to customize your development server.
-
-```javascript
-// static.config.js
-
-export default {
-  devServer: {
-    port: 8080,
-    host: '127.0.0.1'
-  }
-}
-```
-
 ### `devServer`
 An `Object` of options to be passed to the underlying `webpack-dev-server` instance used for developement.
 
@@ -333,7 +318,7 @@ Example:
 export default {
   // An optional object for customizing the options for the
   devServer: {
-    port: 8080,
+    port: 3000,
     host: '127.0.0.1'
   },
 }


### PR DESCRIPTION
The information for devServer config object is repeated twice in the API Reference docs. 

I also would personally would like to see the default port 3000 on the example - helps greatly when searching how to change this setting. Alternative option is to mention something in the line of `Change from default port 3000` in a comment line.