### PR TITLE
styled-components config siteData functional call fix

### DIFF
--- a/examples/styled-components/static.config.js
+++ b/examples/styled-components/static.config.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import { ServerStyleSheet } from 'styled-components'
 
 export default {
-  withSiteData: () => ({
+  getSiteData: () => ({
     title: 'React Static',
   }),
   getRoutes: async () => {


### PR DESCRIPTION
Wrong function called in static.config.js for styled-components demo to get site data, changed from `withSiteData` to `getSiteData`