### PR TITLE
api.md closing tag fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -628,7 +628,7 @@ const Welcome = ({ siteTitle, metaDescription }) => (
   <div>Welcome to {siteTitle}! {metaDescription}</div>
 )
 export default () => (
-  <SiteData component={Welcome}
+  <SiteData component={Welcome} />
 )
 
 // HOC syntax


### PR DESCRIPTION
An example component render is missing a closing tag.