### PR TITLE
Add missing typing for withSiteData

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-static' {
 
   export function getRouteData(comp: any): any
   export function getSiteData(comp: any): any
+  export function withRouteData(comp: any): any
   export function withSiteData(comp: any): any
   export async function prefetch(path: any): any
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,8 +16,6 @@ declare module 'react-static' {
 
   export const Head: Helmet
 
-  export function getRouteData(comp: any): any
-  export function getSiteData(comp: any): any
   export function withRouteData(comp: any): any
   export function withSiteData(comp: any): any
   export async function prefetch(path: any): any

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ declare module 'react-static' {
 
   export function getRouteData(comp: any): any
   export function getSiteData(comp: any): any
+  export function withSiteData(comp: any): any
   export async function prefetch(path: any): any
 
   export const Prefetch: React.Component


### PR DESCRIPTION
Fixes
```
[ts] Module ''react-static'' has no exported member 'withSiteData'.
```
when trying to
```js
import { withSiteData } from 'react-static'
```

Although other type definitions could use a little love as well, IMO this is pretty important to add considering the error shows up immediately after initializing a new project with the [official TypeScript template](https://github.com/nozzle/react-static/tree/master/examples/typescript).