### PR TITLE
Enable Hot Module Replacement for Antd Example

### DIFF
--- a/examples/less-antdesign/static.config.js
+++ b/examples/less-antdesign/static.config.js
@@ -20,6 +20,11 @@ const lessToJs = require('less-vars-to-js')
 
 const themeVariables = lessToJs(fs.readFileSync(path.join(__dirname, 'src/theme-ant-overwrite.less'), 'utf8'))
 
+/*
+* For Hot Module Replacement Support
+* */
+const webpack = require('webpack')
+
 //
 export default {
   getSiteData: () => ({
@@ -95,6 +100,9 @@ export default {
     // Needed for momoent js resolution in React 16
     // See: https://github.com/moment/moment/issues/2979#issuecomment-332217206
     config.resolve.alias.moment$ = 'moment/moment.js'
+
+    // Enable Hot Module Replacement
+    config.plugins.push(new webpack.HotModuleReplacementPlugin())
 
     // We replace the existing JS rule with one, that allows us to use
     // both TypeScript and JavaScript interchangeably


### PR DESCRIPTION
This is a simple fix to enable Hot Module Replacement in the LESS & Antdesign template by pushing the HotModuleReplacementPlugin to the webpack config in `static.config.js`.

Solution found from [this webpack issue](https://github.com/webpack/webpack/issues/1151).

Fixes #318 