### PR TITLE
Remove broken link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ All of the following examples can be used as a template at project creation.
 - [Animated Routes](https://github.com/nozzle/react-static/tree/master/examples/animated-routes)
 - [Custom Routing](https://github.com/nozzle/react-static/tree/master/examples/custom-routing)
 - [Dynamic Imports (code-splitting)](https://github.com/nozzle/react-static/tree/master/examples/dynamic-imports)
-- [Dynamic Imports (code-splitting with SSR)](https://github.com/nozzle/react-static/tree/master/examples/dynamic-imports-with-ssr)
 - [Firebase Auth](https://github.com/nozzle/react-static/tree/master/examples/firebase-auth)
 - [Glamorous & Tailwind CSS](https://github.com/nozzle/react-static/tree/master/examples/glamorous-tailwind)
 - [Glamorous](https://github.com/nozzle/react-static/tree/master/examples/glamorous)


### PR DESCRIPTION
It looks like the "code-splitting with SSR" and "code-splitting" examples are one in the same. The first is a broken link, and the second mentions SSR in the title once you hit the page.