### PR TITLE
Fix missing import - Styled Components Example

### DIFF
--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",
     "styled-components": "^3",
-    "react-static": "^5"
+    "react-static": "^5",
+    "react-hot-loader": "^3.1.3",
   },
   "devDependencies": {
     "babel-plugin-styled-components": "^1.3.0",


### PR DESCRIPTION
include     "react-hot-loader": "^3.1.3",

Fix styled components example