### PR TITLE
Move react-hot-loader/babel out of env.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -27,12 +27,10 @@
         "regenerator": true,
         "moduleName": "babel-runtime"
       }
-    ]
+    ],
+    "react-hot-loader/babel"
   ],
   "env": {
-    "development": {
-      "plugins": ["react-hot-loader/babel"]
-    },
     "test": {
       "presets": [["latest", { "modules": true }], "stage-0", "stage-3", "react"]
     }


### PR DESCRIPTION
The react hot loader babel plugin [already checks the environment it is running in](https://github.com/gaearon/react-hot-loader/blob/572e803fde186d2f2d59754f404c1d9094ca750a/babel.js). As of this PR the plugin does nothing in production, though it is conceivable that it could do something in the future (e.g., removing the `hot` HOC) and therefore it's probably best to just leave it in the standard `plugins` configuration.