### PR TITLE
 add react-hot-loader 4 dep to prismic example

### DIFF
--- a/examples/basic-prismic/package.json
+++ b/examples/basic-prismic/package.json
@@ -6,6 +6,7 @@
     "prismic-javascript": "^1.5.0-beta.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-hot-loader": "^4.0.0-beta.21",
     "react-router": "^4.2.0",
     "react-static": "^5"
   },

--- a/examples/basic-prismic/package.json
+++ b/examples/basic-prismic/package.json
@@ -1,14 +1,6 @@
 {
   "name": "react-static-example-basic",
   "version": "1.0.1",
-  "main": "index.js",
-  "license": "MIT",
-  "scripts": {
-    "start": "react-static start",
-    "stage": "react-static build --staging",
-    "build": "react-static build",
-    "serve": "serve dist -p 3000"
-  },
   "dependencies": {
     "axios": "^0.16.2",
     "prismic-javascript": "^1.5.0-beta.1",
@@ -20,5 +12,13 @@
   "devDependencies": {
     "eslint-config-react-tools": "1.x.x",
     "serve": "^6.1.0"
+  },
+  "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "build": "react-static build",
+    "serve": "serve dist -p 3000",
+    "stage": "react-static build --staging",
+    "start": "react-static start"
   }
 }


### PR DESCRIPTION
when updating to react-hot-loader 4 in this commit https://github.com/nozzle/react-static/commit/135c499637838cc14f30b779b06a812db2aefcee the `examples/basic-primsmic/package.json` wasn't updated causing that example not to work right away when generating with `react-script create` cli