### PR TITLE
Use an apostrophe rather than a prime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -694,7 +694,7 @@ class Router extends Component {
             background: 'rgba(0,0,0,0.05)',
           }}
         >
-          <h2>Oh-no! Something's gone wrong!</h2>
+          <h2>Oh-no! Something’s gone wrong!</h2>
           <pre style={{ whiteSpace: 'normal', color: 'red' }}>
             <code>{this.state.error && this.state.error.toString()}</code>
           </pre>


### PR DESCRIPTION
This patch replaces a prime with an apostrophe (see https://webdesignledger.com/common-typography-mistakes-apostrophes-versus-quotation-marks/). Normally I'd consider this as "not worth the time", but because a prime is used, GitHub's syntax highlighting gets confused and the code is illegible.

----

<img width="653" alt="screen shot 2018-03-01 at 12 57 56 pm" src="https://user-images.githubusercontent.com/571265/36860940-a12355d4-1d50-11e8-8837-1a6a1f78b682.png">
