### PR TITLE
Add options to use extractCssChunks and inlineCss

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,6 +9,8 @@
   - [basePath](#basepath)
   - [stagingBasePath](#stagingbasepath)
   - [devBasePath](#devbasepath)
+  - [extractCssChunks](#extractcsschunks)
+  - [inlineCss](#inlinecss)
   - [Document](#document)
   - [webpack](#webpack)
   - [devServer](#devserver)
@@ -176,6 +178,12 @@ Works exactly like `basePath`, but only when building with the `--staging` build
 
 ### `devBasePath`
 Works exactly like `basePath`, but only when running the dev server.
+
+### `extractCssChunks`
+`extractCssChunks` replaces default `ExtractTextPlugin` with `ExtractCssChunks`. It enables automatic CSS splitting into separate files by routes as well as dynamic components (usign `react-universal-component`). More information about the [plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin) and [why it is useful as a part of CSS delivery optimisation](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin#what-about-glamorous-styled-components-styled-jsx-aphrodite-etc). Defaults to `false`.
+
+### `inlineCss`
+By using `extractCssChunks` option and putting code splitting at appropriate places, your page related CSS file can be minimal. This option allows you to inline your page related CSS in order to speed up your application by reducing the number of requests required for a first paint. Default to `false`.
 
 ### `Document`
 It's never been easier to customize the root document of your website! `Document` is an optional (and again, recommended) react component responsible for rendering the root of your website.

--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -101,6 +101,8 @@ export default function getConfig (customConfig) {
     basePath: basePath || '',
     stagingBasePath: stagingBasePath || '',
     devBasePath: devBasePath || '',
+    extractCssChunks: config.extractCssChunks || false,
+    inlineCss: config.inlineCss || false,
     getRoutes,
   }
 

--- a/src/static/webpack/rules/cssLoader.js
+++ b/src/static/webpack/rules/cssLoader.js
@@ -1,8 +1,9 @@
 import autoprefixer from 'autoprefixer'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import ExtractCssChunks from 'extract-css-chunks-webpack-plugin'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 
-export default function ({ stage }) {
+export default function ({ config, stage }) {
   if (stage === 'dev') {
     return {
       test: /\.css$/,
@@ -41,7 +42,7 @@ export default function ({ stage }) {
   }
   return {
     test: /\.css$/,
-    loader: ExtractTextPlugin.extract({
+    loader: (config.extractCssChunks ? ExtractCssChunks : ExtractTextPlugin).extract({
       fallback: {
         loader: 'style-loader',
         options: {

--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -3,6 +3,7 @@ import path from 'path'
 import CaseSensitivePathsPlugin from 'case-sensitive-paths-webpack-plugin'
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer'
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import ExtractCssChunks from 'extract-css-chunks-webpack-plugin'
 import nodeExternals from 'webpack-node-externals'
 // import SWPrecacheWebpackPlugin from 'sw-precache-webpack-plugin'
 // import WebpackPwaManifest from 'webpack-pwa-manifest'
@@ -60,13 +61,15 @@ export default function ({ config, isNode }) {
     },
     plugins: [
       new webpack.EnvironmentPlugin(process.env),
-      new ExtractTextPlugin({
-        filename: getPath => {
-          process.env.extractedCSSpath = getPath('styles.[hash:8].css')
-          return process.env.extractedCSSpath
-        },
-        allChunks: true,
-      }),
+      config.extractCssChunks ?
+        new ExtractCssChunks() :
+        new ExtractTextPlugin({
+          filename: getPath => {
+            process.env.extractedCSSpath = getPath('styles.[hash:8].css')
+            return process.env.extractedCSSpath
+          },
+          allChunks: true,
+        }),
       new CaseSensitivePathsPlugin(),
       !isNode &&
         new webpack.optimize.CommonsChunkPlugin({


### PR DESCRIPTION
Two config options were added:

1. `extractCssChunks` - replaces default `ExtractTextPlugin` with `ExtractCssChunks`. It enables automatic CSS splitting into separate files by routes as well as dynamic components (usign `react-universal-component`). More information about the [plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin) and [why it is useful as a part of CSS delivery optimisation](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin#what-about-glamorous-styled-components-styled-jsx-aphrodite-etc). Defaults to `false`.
2. `inlineCss`. By using extractCssChunks option and putting code splitting at appropriate places, your page related CSS file can be minimal. This option allows you to inline your page related CSS in order to speed up your application by reducing the number of requests required for a first paint. Default to false.

Worth to mention in the changelog: if project has custom CSS loader with `ExtractTextPlugin`, `extractCssChunks` will cause an error during the build. That could be solved by replacing the plugin manually in custom loader.