### PR TITLE
Prevent scroll from being stuck

### DIFF
--- a/src/utils/scrollTo.js
+++ b/src/utils/scrollTo.js
@@ -49,6 +49,13 @@ export default function scrollTo (element, options) {
         resolve()
         return
       }
+
+      // Sanity check to prevent taking over the scroll once we prematurely got to the element
+      if (start === end) {
+        resolve()
+        return
+      }
+
       raf(step)
     }
     raf(step)


### PR DESCRIPTION
Whatever the reason behind the scroll getting to the location too early,
if we do not abort, we will continue doing no-op `window.scroll` operations
for the rest of duration. This means that the user in the meantime can not scroll.

Fixes #449.
