### PR TITLE
Fix corner case of hash scroll not happening

### DIFF
--- a/src/client/components/RouterScroller.js
+++ b/src/client/components/RouterScroller.js
@@ -41,24 +41,33 @@ const RouterScroller = withRouter(
       if (!autoScrollToHash) {
         return
       }
-      RAF(() => {
-        if (hash) {
-          const resolvedHash = hash.substring(1)
-          if (resolvedHash) {
-            const element = document.getElementById(resolvedHash)
-            if (element !== null) {
-              scrollTo(element, {
-                duration: scrollToHashDuration,
-                offset: scrollToHashOffset,
-              })
-            }
+      if (hash) {
+        const resolvedHash = hash.substring(1)
+        if (resolvedHash) {
+          // We must attempt to scroll synchronously or we risk the browser scrolling for us
+          const element = document.getElementById(resolvedHash)
+          if (element !== null) {
+            scrollTo(element, {
+              duration: scrollToHashDuration,
+              offset: scrollToHashOffset,
+            })
+          } else {
+            RAF(() => {
+              const element = document.getElementById(resolvedHash)
+              if (element !== null) {
+                scrollTo(element, {
+                  duration: scrollToHashDuration,
+                  offset: scrollToHashOffset,
+                })
+              }
+            })
           }
-        } else {
-          scrollTo(0, {
-            duration: scrollToHashDuration,
-          })
         }
-      })
+      } else {
+        scrollTo(0, {
+          duration: scrollToHashDuration,
+        })
+      }
     }
     render () {
       return unwrapArray(this.props.children)


### PR DESCRIPTION
In my codebase that I did not manage to reduce for a demonstration,
RAF would delay the scrollTo call so much that the browser would have already instanly scrolled us to the correct location.
As a result the scrollTo would then be a no-op.

Instead, we now attempt to scroll as soon as possible, synchronously,
and fall back on RAF if that did not work.

Fixup efbaa1618. Fixes #449. Related to #460, but does not make that irrelevant.
