### PR TITLE
Example Maintenance: TypeScript & fix Less-AntDesign

### DIFF
--- a/examples/less-antdesign/package.json
+++ b/examples/less-antdesign/package.json
@@ -10,33 +10,33 @@
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
-    "antd": "next",
-    "axios": "^0.17.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "antd": "3.3.0",
+    "axios": "^0.18.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-router": "^4.2.0",
     "react-static": "^5",
-    "styled-components": "2.2.3"
+    "styled-components": "3.2.1"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
-    "@types/node": "^8.0.49",
-    "@types/react": "^16.0.18",
+    "@types/node": "^9.4.7",
+    "@types/react": "^16.0.40",
     "@types/react-dom": "^16.0.2",
-    "@types/react-hot-loader": "^3.0.5",
-    "@types/react-router": "^4.0.16",
-    "autoprefixer": "^7.1.6",
-    "babel-plugin-import": "^1.6.2",
+    "@types/react-hot-loader": "^3.0.6",
+    "@types/react-router": "^4.0.22",
+    "autoprefixer": "^8.1.0",
+    "babel-plugin-import": "^1.6.6",
     "babel-register": "^6.26.0",
     "convert-tsconfig-paths-to-webpack-aliases": "^0.9.2",
-    "eslint-config-react-tools": "1.x.x",
+    "eslint-config-react-tools": "1.1.2",
     "extract-text-webpack-plugin": "^3.0.2",
-    "less": "^2.7.3",
-    "less-loader": "^4.0.5",
-    "less-vars-to-js": "^1.2.0",
-    "postcss-flexbugs-fixes": "^3.2.0",
-    "serve": "^6.4.1",
-    "ts-loader": "^3.1.1",
-    "typescript": "^2.6.1"
+    "less": "^3.0.1",
+    "less-loader": "^4.1.0",
+    "less-vars-to-js": "^1.2.1",
+    "postcss-flexbugs-fixes": "^3.3.0",
+    "serve": "^6.5.3",
+    "ts-loader": "^3.5.0",
+    "typescript": "^2.7.2"
   }
 }

--- a/examples/less-antdesign/static.config.js
+++ b/examples/less-antdesign/static.config.js
@@ -173,6 +173,7 @@ export default {
               options: {
                 sourceMap: true,
                 modifyVars: themeVariables,
+                javascriptEnabled: true,
               },
             },
           ],
@@ -224,6 +225,7 @@ export default {
                 options: {
                   sourceMap: false,
                   modifyVars: themeVariables,
+                  javascriptEnabled: true,
                 },
               },
             ],

--- a/examples/less-antdesign/static.config.js
+++ b/examples/less-antdesign/static.config.js
@@ -129,7 +129,6 @@ export default {
     let lessLoader = {}
 
     if (stage === 'dev') {
-
       // Enable Hot Module Replacement
       config.plugins.push(new webpack.HotModuleReplacementPlugin())
 

--- a/examples/less-antdesign/static.config.js
+++ b/examples/less-antdesign/static.config.js
@@ -20,6 +20,8 @@ const lessToJs = require('less-vars-to-js')
 
 const themeVariables = lessToJs(fs.readFileSync(path.join(__dirname, 'src/theme-ant-overwrite.less'), 'utf8'))
 
+const webpack = require('webpack')
+
 //
 export default {
   getSiteData: () => ({
@@ -127,6 +129,10 @@ export default {
     let lessLoader = {}
 
     if (stage === 'dev') {
+
+      // Enable Hot Module Replacement
+      config.plugins.push(new webpack.HotModuleReplacementPlugin())
+
       // In-Line with style-loader
       lessLoader =
         {

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -10,25 +10,25 @@
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
-    "axios": "^0.17.0",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0",
+    "axios": "^0.18.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-router": "^4.2.0",
     "react-static": "^5"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
-    "@types/node": "^8.0.47",
-    "@types/react": "^16.0.18",
-    "@types/react-dom": "^16.0.2",
-    "@types/react-hot-loader": "^3.0.5",
+    "@types/node": "^9.4.7",
+    "@types/react": "^16.0.40",
+    "@types/react-dom": "^16.0.4",
+    "@types/react-hot-loader": "^3.0.6",
     "@types/react-router": "^4.0.16",
-    "@types/webpack-env": "^1.13.3",
+    "@types/webpack-env": "^1.13.5",
     "convert-tsconfig-paths-to-webpack-aliases": "^0.9.2",
-    "eslint-config-react-tools": "1.x.x",
-    "serve": "^6.4.1",
-    "ts-loader": "^3.1.1",
-    "typescript": "^2.6.1"
+    "eslint-config-react-tools": "1.1.2",
+    "serve": "^6.5.3",
+    "ts-loader": "^3.5.0",
+    "typescript": "^2.7.2"
   },
   "prettier": {
     "semi": false,


### PR DESCRIPTION
fixes #367 
fixes #318 

  ### Is this a bug report?

The typescript example was outdated. `ts-loader` is **fixed to v3.x** until react-static ventures into webpack 4.

The antdesign example **would neither start nor build anymore**. Reasons were the changed HMR system and an internal change of how flexible the antd less files are now.
 
 ### Steps to Reproduce
 
 1. Try to update TypeScript example and build
 2. Try to run or build a less-antdesign example
 3. (Please Note: less-antdesign is based on the TypeScript Example)

 ### Expected Behavior
 
Both examples should run and build.
 
 ### Actual Behavior
 
Both examples don't run and build.

 ### Change through this PR

- Both Examples have been updated to its latest dependencies
- Both Examples have been checked to properly
  - run
  - Hot Module Replace with vanilla JS and TypeScript use
  - build
  - serve

![image](https://user-images.githubusercontent.com/2397125/37300070-58580a88-2625-11e8-8ccd-bba1ab1ee464.png)
