### PR TITLE
Fixed --config arguments

### DIFF
--- a/bin/react-static-build
+++ b/bin/react-static-build
@@ -7,7 +7,7 @@ const buildCmd = require('../lib/commands/build')
 
 // use commander to parse CLI args
 program
-  .option('-c, --config', 'path to custom static.config.js')
+  .option('-c, --config <path>', 'path to custom static.config.js')
   .option('-s, --staging', 'set to staging mode')
   .option('-d, --debug', 'set to debug mode')
   .parse(process.argv)

--- a/bin/react-static-start
+++ b/bin/react-static-start
@@ -7,7 +7,7 @@ const startCmd = require('../lib/commands/start')
 
 // use commander to parse CLI args
 program
-  .option('-c, --config', 'path to custom static.config.js')
+  .option('-c, --config <path>', 'path to custom static.config.js')
   .option('-d, --debug', 'set to debug mode')
   .parse(process.argv)
 


### PR DESCRIPTION
682d35a9c930386133997b86d603b9be85495628 broke the ability to use --config to point to a static.config.js file.

Non-boolean options should include a `<value>` segment in the option commander definition.