### PR TITLE
Update Material UI example to use recently renamed CssBaseline component

### DIFF
--- a/examples/material-ui/package.json
+++ b/examples/material-ui/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
-    "material-ui": "^1.0.0-beta.27",
-    "material-ui-icons": "^1.0.0-beta.17",
+    "material-ui": "^1.0.0-beta.37",
+    "material-ui-icons": "^1.0.0-beta.36",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router": "^4.2.0",

--- a/examples/material-ui/src/App.js
+++ b/examples/material-ui/src/App.js
@@ -4,7 +4,7 @@ import { hot } from 'react-hot-loader'
 //
 import Routes from 'react-static-routes'
 
-import Reboot from 'material-ui/Reboot'
+import CssBaseline from 'material-ui/CssBaseline'
 import AppBar from 'material-ui/AppBar'
 import Tabs, { Tab } from 'material-ui/Tabs'
 import { withStyles } from 'material-ui/styles'
@@ -42,7 +42,7 @@ class App extends PureComponent {
     return (
       <Router>
         <div className={classes.container}>
-          <Reboot />
+          <CssBaseline />
           <AppBar className={classes.appBar} color="default" position="static">
             <nav>
               <Tabs className={classes.tabs} value={false}>


### PR DESCRIPTION
 ### Is this a bug report?
 
Yes.

The Material UI example cannot currently be used due to:
`Module not found: Can't resolve 'material-ui/Reboot'`

This is a recent breaking change in Material UI v1.0.0-beta.37:
https://github.com/mui-org/material-ui/pull/10605
https://github.com/mui-org/material-ui/releases


 ### Environment
 
 1. `react-static -v`: 5.6.1 
 2. `node -v`: 8.10.0
 3. `yarn --version or npm -v`: 1.3.2
 4. Operating system: macOS 10.13.3


 ### Steps to Reproduce
 
 1. Create a new React Static site using the `material-ui` template
 2. Run `yarn start` (or `yarn build`)


 ### Expected Behavior
 
 The app should be served at http://localhost:3000
 

 ### Actual Behavior
 
The node process dies with `Module not found: Can't resolve 'material-ui/Reboot'`
 