### PR TITLE
TypeScript: Excluded node_modules in tsconfig.json

### DIFF
--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -31,6 +31,7 @@
   },
   "exclude": [
     "dist/**/*",
-    "public/**/*"
+    "public/**/*",
+    "node_modules"
   ]
 }


### PR DESCRIPTION
I'm pretty sure `node_modules` should be excluded - this was preventing my dev environment to load React-specific types correctly.

[According to the official doc](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html):

> The `"exclude"` property defaults to excluding the `node_modules`, `bower_components`, `jspm_packages` and `<outDir>` directories when not specified.

## If `node_modules` was not excluded

My `code` tag isn't using type definitions from `@type/react`:

<img width="531" alt="screen shot 2018-03-17 at 11 37 05 pm" src="https://user-images.githubusercontent.com/992008/37563360-3d4cb548-2a3c-11e8-924e-44ee205a1ff9.png">

## If `node_modules` was excluded

My `code` tag uses type definitions from `@type/react`:

<img width="569" alt="screen shot 2018-03-17 at 11 40 54 pm" src="https://user-images.githubusercontent.com/992008/37563380-a794574e-2a3c-11e8-9d26-abd5da5323f3.png">
