### PR TITLE
Show URL and component path of error during build

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -277,13 +277,20 @@ export const exportRoutes = async ({ config, clientStats }) => {
         return appHtml
       }
 
-      // Allow extractions of meta via config.renderToString
-      const appHtml = await config.renderToHtml(
-        renderToStringAndExtract,
-        FinalComp,
-        renderMeta,
-        clientStats
-      )
+      let appHtml
+
+      try {
+        // Allow extractions of meta via config.renderToString
+        appHtml = await config.renderToHtml(
+          renderToStringAndExtract,
+          FinalComp,
+          renderMeta,
+          clientStats
+        )
+      } catch (error) {
+        error.message = `Failed exporting HTML for URL /${route.path}/ (${route.component}): ${error.message}`
+        throw error
+      }
 
       // Instead of using the default components, we need to hard code meta
       // from react-helmet into the components


### PR DESCRIPTION
When build fails, I am often missing the URL and component which failed. This enhances the original Error message with info about those things.