### PR TITLE
Using pretty-error package for nicer error reporting during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,8 @@
     "buildDocs": "gitdocs build",
     "serveDocs": "serve docs-dist -p 3000",
     "test": "eslint src examples test && yarn run test-sample-build",
-    "test-large-build":
-      "yarn build && (cd test/stress-test-routes && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)",
-    "test-sample-build":
-      "yarn build && (cd test/minimal-website && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)"
+    "test-large-build": "yarn build && (cd test/stress-test-routes && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)",
+    "test-sample-build": "yarn build && (cd test/minimal-website && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)"
   },
   "dependencies": {
     "@types/react": "^16.0.18",
@@ -76,6 +74,7 @@
     "postcss-loader": "^2.0.6",
     "preact": "^8.2.7",
     "preact-compat": "^3.17.0",
+    "pretty-error": "^2.1.1",
     "progress": "^2.0.0",
     "prop-types": "^15.5.10",
     "raf": "^3.4.0",

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -64,10 +64,16 @@ export default async function build ({ config, staging, debug, isCLI, silent = !
     await new Promise(() => {})
   }
 
-  await exportRoutes({
-    config,
-    clientStats,
-  })
+  try {
+    await exportRoutes({
+      config,
+      clientStats,
+    })
+  } catch (e) {
+    const PrettyError = require('pretty-error')
+    console.log() // new line
+    console.log(new PrettyError().render(e))
+  }
   await buildXMLandRSS({ config })
 
   if (!silent) console.timeEnd('=> Site is ready for production!')

--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -73,6 +73,7 @@ export default async function build ({ config, staging, debug, isCLI, silent = !
     const PrettyError = require('pretty-error')
     console.log() // new line
     console.log(new PrettyError().render(e))
+    process.exit(1)
   }
   await buildXMLandRSS({ config })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6450,7 +6450,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretty-error@^2.0.2:
+pretty-error@^2.0.2, pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
   dependencies:


### PR DESCRIPTION
Before:

<img width="1015" alt="screen shot 2018-03-18 at 21 53 36" src="https://user-images.githubusercontent.com/316435/37570958-d9c9b082-2af6-11e8-9b8a-ac3eaf46c258.png">

After:

<img width="993" alt="screen shot 2018-03-18 at 21 52 29" src="https://user-images.githubusercontent.com/316435/37570959-e1418042-2af6-11e8-95fd-6d16d077fe5f.png">

I would like to see this also in watch mode.