### PR TITLE
Serve directly from public.

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -5,7 +5,7 @@ import { prepareRoutes } from '../static'
 import { DefaultDocument } from '../static/RootComponents'
 import { startDevServer } from '../static/webpack'
 import getConfig from '../static/getConfig'
-import { copyPublicFolder, createIndexFilePlaceholder } from '../utils'
+import { createIndexFilePlaceholder } from '../utils'
 //
 
 export default async function start ({ config, isCLI, debug, silent = !isCLI } = {}) {

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -40,13 +40,6 @@ export default async function start ({ config, isCLI, debug, silent = !isCLI } =
     siteData,
   })
 
-  // Copy the public directory over
-  if (!silent) console.log('')
-  if (!silent) console.log('=> Copying public directory...')
-  console.time(chalk.green('=> [\u2713] Public directory copied'))
-  copyPublicFolder(config)
-  console.timeEnd(chalk.green('=> [\u2713] Public directory copied'))
-
   // Build the dynamic routes file (react-static-routes)
   if (!silent) console.log('=> Building Routes...')
   console.time(chalk.green('=> [\u2713] Routes Built'))

--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -76,7 +76,7 @@ export async function startDevServer ({ config }) {
   const devServerConfig = {
     hot: true,
     disableHostCheck: true,
-    contentBase: config.paths.DIST,
+    contentBase: [config.paths.PUBLIC, config.paths.DIST],
     publicPath: '/',
     historyApiFallback: true,
     compress: false,


### PR DESCRIPTION
Serve directly from the public directory rather than copying it's contents ahead of time.  Makes it much easier to tweak files and get instant feedback.  (admin/config.yml for Netlify CMS in my case)

Closes #484