### PR TITLE
Fix losing internal state in components on hash navigation

### DIFF
--- a/src/static/generateRoutes.js
+++ b/src/static/generateRoutes.js
@@ -108,7 +108,10 @@ export default class Routes extends Component {
     return (
       <Route path='*' render={props => {
         let Comp = getFullComponentForPath(props.location.pathname)
-        return <Comp key={props.location.pathname} {...props} />
+        // If Comp is used as a component here, it triggers React to re-mount the entire
+        // component tree underneath during reconciliation, losing all internal state.
+        // By unwrapping it here we keep the real, static component exposed directly to React.
+        return Comp && Comp({ ...props, key: props.location.pathname })
       }} />
     )
   }


### PR DESCRIPTION
Attempt to fix #487.

The likely cause is the dynamic generation of the component which does not pass React reconciliation check. [An article by Huy Nguyen](https://www.huy-nguyen.com/2017-01-avoid-unnecessary-remounting-react/) explains it in more detail. In our code it’s in `generateRoutes`:

https://github.com/nozzle/react-static/blob/dfd927c5c24977e16d13debe807872fca2fe2e0e/src/static/generateRoutes.js#L82-L86

dfd927c5c2 may have been an attempt to fix it, but it does not help.

Currently this workaround in my code works:

```js
const workAroundRender = reactStaticProps => {
  const render = props => {
    const Comp = reactStaticProps.getComponentForPath(props.location.pathname);
    return Comp && Comp(props);
  };
  return <Route path="*" render={render} />;
};

<Routes render={workAroundRender} />
```

The proposed change is the simplest that fixes my codebase. I realize this change is hard to maintain and easy to break again. If you figure a different way to fix this, feel free to close the PR.
