### PR TITLE
Keep user's devServer.watchOptions when running dev server

### DIFF
--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -84,7 +84,7 @@ export async function startDevServer ({ config }) {
     ...config.devServer,
     watchOptions: {
       ignored: /node_modules/,
-      ...((config.devServer) ? config.devServer.watchOptions : {}),
+      ...((config.devServer) ? (config.devServer.watchOptions) || {} : {}),
     },
     before: app => {
       // Serve the site data

--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -81,10 +81,11 @@ export async function startDevServer ({ config }) {
     historyApiFallback: true,
     compress: false,
     quiet: true,
+    ...config.devServer,
     watchOptions: {
       ignored: /node_modules/,
+      ...((config.devServer) ? config.devServer.watchOptions : {}),
     },
-    ...config.devServer,
     before: app => {
       // Serve the site data
       app.get('/__react-static__/siteData', async (req, res, next) => {


### PR DESCRIPTION
Closes https://github.com/nozzle/react-static/issues/479