### PR TITLE
Disable NODE_ENV=production in build --debug

### DIFF
--- a/src/commands/build.js
+++ b/src/commands/build.js
@@ -8,7 +8,7 @@ import { copyPublicFolder } from '../utils'
 
 export default async function build ({ config, staging, debug, isCLI, silent = !isCLI } = {}) {
   // ensure ENV variables are set
-  if (typeof process.env.NODE_ENV === 'undefined') {
+  if (typeof process.env.NODE_ENV === 'undefined' && !debug) {
     process.env.NODE_ENV = 'production'
   }
   process.env.REACT_STATIC_ENV = 'production'


### PR DESCRIPTION
Fix #500. Also removes React warning about unminified React in production.

I’m not sure you want this as the best solution to #500. After all, this makes it so that `build --debug` is now one step more different from production. At the same time it was super strange that `--debug` does not show, you know, debug information. Finally, maybe we think that non-minification already makes this build far enough from production, so might as well not set NODE_ENV.

This is a judgement call, and I am not sure about this solution, thus this PR is separate from the issue.