### PR TITLE
Add Browser Support link to navigation. Detail how to extend static.c…

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -293,3 +293,19 @@ React-Static dually relies on lowest common browser support between React itself
 
 - All latest versions of modern browsers (Chrome, Firefox, Safari) are supported out of the box.
 - Internet Explorer is supported, but requires using `babel-polyfill` to work (mainly relying on the `Promise` polyfill)
+
+To extend `static.config.js` for compatibility with Internet Explorer, first install `babel-polyfill`:
+`yarn add babel-polyfill`
+
+Then add the following webpack object to the default export of `static.config.js` to extend the existing webpack configuration:
+
+```javascript
+webpack: (config, { stage }) => {
+  if (stage === 'prod') {
+    config.entry = ['babel-polyfill', config.entry]
+  } else if (stage === 'dev') {
+    config.entry = ['babel-polyfill', ...config.entry]
+  }
+  return config
+},
+```

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -55,6 +55,7 @@ module.exports = {
             src: 'concepts.md#using-preact-in-production',
           },
           { name: 'Pagination', src: 'concepts.md#pagination' },
+          { name: 'Browser Support', src: 'concepts.md#browser-support' },
         ],
       },
       {


### PR DESCRIPTION
Add Browser Support link to navigation. Detail how to extend static.confg.js to enable IE support through babel/promise polyfill


 ### Is this a bug report?
 
No
 