### PR TITLE
Fix 404s on homepage at first load

### DIFF
--- a/src/client/components/Router.js
+++ b/src/client/components/Router.js
@@ -67,7 +67,7 @@ export default class Router extends React.Component {
     (async () => {
       if (typeof window !== 'undefined') {
         // Get the entry path from location
-        const href = decodeURIComponent(window.location)
+        const href = decodeURIComponent(window.location.href)
         const path = cleanPath(href)
 
         // Injest and cache the embedded routeInfo in the page if possible


### PR DESCRIPTION
When first loading an app in dev mode there was a request to `/_react-static_/routeinfo/undefined`. This fixes the issue.

fixes #523