### PR TITLE
Fixes a missing dependency that is required in binHelper

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "style-loader": "^0.19.0",
     "swimmer": "^1.1.1",
     "url-loader": "^0.6.1",
+    "update-notifier": "^2.4.0",
     "webpack": "^3.6.0",
     "webpack-bundle-analyzer": "^2.9.0",
     "webpack-dev-server": "^2.8.2",


### PR DESCRIPTION
This issue causes react static to break at startup.

since it's very simple I just skipped the whole description. 