### PR TITLE
Fixes issue with error page showing in production

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
   extends: 'react-tools',
+  env: {
+    jest: true,
+  },
 }

--- a/docs/components.md
+++ b/docs/components.md
@@ -41,6 +41,7 @@ Props:
 * `scrollToHashDuration: Int` - The duration of the automatic scroll-to-hash animation that happens on hash changes. Defaults to `800`
 * `scrollToHashOffset: Int` - The vertical offset of the automatic scroll-to-hash animation that happens on path changes. Defaults to `0`
 * `history: History` - An optional history object (most-often used for things like react-router-redux). Provides a helper method to subscribe to loading events. Note that this will override the `type` prop above.
+* `showErrorsInProduction: Boolean` - Set this to `true` to enable the debug/error page in production. Defaults to `false`.
 
 Example:
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "startDocs": "gitdocs serve",
     "buildDocs": "gitdocs build",
     "serveDocs": "serve docs-dist -p 3000",
-    "test": "eslint src examples test && yarn run test-sample-build",
+    "test": "yarn jest && eslint src examples test && yarn run test-sample-build",
     "test-large-build": "yarn build && (cd test/stress-test-routes && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)",
     "test-sample-build": "yarn build && (cd test/minimal-website && yarn && rm -rf node_modules/react-static && ln -s -f ../../../ ./node_modules/react-static && ../../bin/react-static build)"
   },
@@ -102,6 +102,9 @@
     "webpack-node-externals": "^1.6.0"
   },
   "devDependencies": {
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.3",
     "eslint": "^4.3.0",
     "gitdocs": "^1.5.17",
     "jest": "^21.2.1",
@@ -110,5 +113,15 @@
   "prettier": {
     "semi": false,
     "singleQuote": true
+  },
+  "jest": {
+    "verbose": true,
+    "testRegex": "(/__tests__/.*\\.(test))\\.jsx?$",
+    "setupFiles": [
+      "<rootDir>/setupTests.js"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
   }
 }

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,0 +1,7 @@
+import 'raf/polyfill'
+
+const Enzyme = require('enzyme')
+const EnzymeAdapter = require('enzyme-adapter-react-16')
+
+// Setup enzyme's react adapter
+Enzyme.configure({ adapter: new EnzymeAdapter() })

--- a/src/client/components/ErrorWrapper/ErrorCatcher.js
+++ b/src/client/components/ErrorWrapper/ErrorCatcher.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ErrorUI from './ErrorUI'
+
+export default class ErrorCatcher extends React.Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+  }
+
+  state = {
+    error: null,
+    errorInfo: null,
+  }
+
+  componentDidCatch (error, errorInfo) {
+    // Catch errors in any child components and re-renders with an error message
+    this.setState({
+      error,
+      errorInfo,
+    })
+  }
+
+  render () {
+    const { error } = this.state
+
+    // Fallback UI if an error occurs
+    if (error) {
+      return <ErrorUI {...this.state} />
+    }
+
+    return React.Children.only(this.props.children)
+  }
+}

--- a/src/client/components/ErrorWrapper/ErrorUI.js
+++ b/src/client/components/ErrorWrapper/ErrorUI.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const ErrorUI = ({ error, errorInfo }) => (
+  <div
+    style={{
+      margin: '1rem',
+      padding: '1rem',
+      background: 'rgba(0,0,0,0.05)',
+    }}
+  >
+    <h2>Oh-no! Something’s gone wrong!</h2>
+    <pre style={{ whiteSpace: 'normal', color: 'red' }}>
+      <code>{error && error.toString()}</code>
+    </pre>
+    <h3>This error occurred here:</h3>
+    <pre style={{ color: 'red', overflow: 'auto' }}>
+      <code>{errorInfo.componentStack}</code>
+    </pre>
+    <p>For more information, please see the console.</p>
+  </div>
+)
+
+ErrorUI.propTypes = {
+  error: PropTypes.object.isRequired,
+  errorInfo: PropTypes.object.isRequired,
+}
+
+export default ErrorUI

--- a/src/client/components/ErrorWrapper/__tests__/ErrorCatcher.test.js
+++ b/src/client/components/ErrorWrapper/__tests__/ErrorCatcher.test.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import ErrorCatcher from '../ErrorCatcher'
+
+describe('ErrorCatcher', () => {
+  test('by default should render children', () => {
+    const errorCatcher = shallow(
+      <ErrorCatcher>
+        <span>hello</span>
+      </ErrorCatcher>
+    )
+
+    expect(errorCatcher).toMatchSnapshot()
+  })
+
+  describe('when children throw an error', () => {
+    it('should catch errors with componentDidCatch', () => {
+      const ChildComponentWithError = () => {
+        throw new Error('Error thrown from problem child')
+      }
+
+      jest.spyOn(ErrorCatcher.prototype, 'componentDidCatch')
+
+      const errorCatcher = mount(
+        <ErrorCatcher>
+          <ChildComponentWithError />
+        </ErrorCatcher>
+      )
+
+      expect(ErrorCatcher.prototype.componentDidCatch).toHaveBeenCalled()
+      expect(errorCatcher.state('error')).toEqual(new Error('Error thrown from problem child'))
+      expect(errorCatcher.state('errorInfo')).toMatchSnapshot()
+      expect(errorCatcher).toMatchSnapshot()
+    })
+  })
+})

--- a/src/client/components/ErrorWrapper/__tests__/__snapshots__/ErrorCatcher.test.js.snap
+++ b/src/client/components/ErrorWrapper/__tests__/__snapshots__/ErrorCatcher.test.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorCatcher by default should render children 1`] = `
+<span>
+  hello
+</span>
+`;
+
+exports[`ErrorCatcher when children throw an error should catch errors with componentDidCatch 1`] = `
+Object {
+  "componentStack": "
+    in ChildComponentWithError
+    in ErrorCatcher (created by WrapperComponent)
+    in WrapperComponent",
+}
+`;
+
+exports[`ErrorCatcher when children throw an error should catch errors with componentDidCatch 2`] = `
+<ErrorCatcher>
+  <ErrorUI
+    error={[Error: Error thrown from problem child]}
+    errorInfo={
+      Object {
+        "componentStack": "
+    in ChildComponentWithError
+    in ErrorCatcher (created by WrapperComponent)
+    in WrapperComponent",
+      }
+    }
+  >
+    <div
+      style={
+        Object {
+          "background": "rgba(0,0,0,0.05)",
+          "margin": "1rem",
+          "padding": "1rem",
+        }
+      }
+    >
+      <h2>
+        Oh-no! Something’s gone wrong!
+      </h2>
+      <pre
+        style={
+          Object {
+            "color": "red",
+            "whiteSpace": "normal",
+          }
+        }
+      >
+        <code>
+          Error: Error thrown from problem child
+        </code>
+      </pre>
+      <h3>
+        This error occurred here:
+      </h3>
+      <pre
+        style={
+          Object {
+            "color": "red",
+            "overflow": "auto",
+          }
+        }
+      >
+        <code>
+          
+    in ChildComponentWithError
+    in ErrorCatcher (created by WrapperComponent)
+    in WrapperComponent
+        </code>
+      </pre>
+      <p>
+        For more information, please see the console.
+      </p>
+    </div>
+  </ErrorUI>
+</ErrorCatcher>
+`;

--- a/src/client/components/ErrorWrapper/__tests__/__snapshots__/index.test.js.snap
+++ b/src/client/components/ErrorWrapper/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ErrorWrapper when process.env.REACT_STATIC_ENV is \`development\` should wrap the child with the ErrorCatcher 1`] = `
+<ErrorCatcher>
+  <span>
+    hello
+  </span>
+</ErrorCatcher>
+`;
+
+exports[`ErrorWrapper when process.env.REACT_STATIC_ENV is \`production\` should not wrap the child with the ErrorCatcher 1`] = `
+<span>
+  hello
+</span>
+`;
+
+exports[`ErrorWrapper when process.env.REACT_STATIC_ENV is \`production\` when showErrorsInProduction is defined should wrap the child with the ErrorCatcher 1`] = `
+<ErrorCatcher>
+  <span>
+    hello
+  </span>
+</ErrorCatcher>
+`;

--- a/src/client/components/ErrorWrapper/__tests__/index.test.js
+++ b/src/client/components/ErrorWrapper/__tests__/index.test.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ErrorWrapper from '../index'
+
+describe('ErrorWrapper', () => {
+  let reactStaticEnviroment
+
+  beforeEach(() => {
+    reactStaticEnviroment = process.env.REACT_STATIC_ENV
+  })
+
+  describe('when process.env.REACT_STATIC_ENV is `development`', () => {
+    it('should wrap the child with the ErrorCatcher', () => {
+      process.env.REACT_STATIC_ENV = 'development'
+
+      const errorWrapper = shallow(
+        <ErrorWrapper>
+          <span>hello</span>
+        </ErrorWrapper>
+      )
+
+      expect(errorWrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('when process.env.REACT_STATIC_ENV is `production`', () => {
+    it('should not wrap the child with the ErrorCatcher', () => {
+      process.env.REACT_STATIC_ENV = 'production'
+
+      const errorWrapper = shallow(
+        <ErrorWrapper >
+          <span>hello</span>
+        </ErrorWrapper>
+      )
+
+      expect(errorWrapper).toMatchSnapshot()
+    })
+
+    describe('when showErrorsInProduction is defined', () => {
+      it('should wrap the child with the ErrorCatcher', () => {
+        process.env.REACT_STATIC_ENV = 'production'
+
+        const errorWrapper = shallow(
+          <ErrorWrapper showErrorsInProduction>
+            <span>hello</span>
+          </ErrorWrapper>
+        )
+
+        expect(errorWrapper).toMatchSnapshot()
+      })
+    })
+  })
+
+  afterEach(() => {
+    process.env.REACT_STATIC_ENV = reactStaticEnviroment
+  })
+})

--- a/src/client/components/ErrorWrapper/index.js
+++ b/src/client/components/ErrorWrapper/index.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ErrorCatcher from './ErrorCatcher'
+
+const ErrorWrapper = ({ showErrorsInProduction, children }) => {
+  if (process.env.REACT_STATIC_ENV === 'development' || showErrorsInProduction) {
+    return <ErrorCatcher>{children}</ErrorCatcher>
+  }
+
+  return React.Children.only(children)
+}
+
+ErrorWrapper.propTypes = {
+  showErrorsInProduction: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+}
+
+ErrorWrapper.defaultProps = {
+  showErrorsInProduction: false,
+}
+
+export default ErrorWrapper

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,6 +48,7 @@ declare module 'react-static' {
     autoScrollToHash?: boolean;
     scrollToHashDuration?: number;
     scrollToTopDuration?: number;
+    showErrorsInProduction?: boolean;
   }> {}
 
   export const NavLink: undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,10 @@
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
 
+"@types/node@*":
+  version "9.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.4.tgz#0ef7b4cfc3499881c81e0ea1ce61a23f6f4f5b42"
+
 "@types/react-helmet@^5.0.3":
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.5.tgz#30a12b0431732a20882f0fa9b75bf56ff91700d3"
@@ -1833,6 +1837,17 @@ check-types@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.3.0.tgz#468f571a4435c24248f5fd0cb0e8d87c3c341e7d"
 
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -2025,6 +2040,10 @@ colormin@^1.0.5:
     color "^0.11.0"
     css-color-names "0.0.4"
     has "^1.0.1"
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
 
 colors@~1.1.2:
   version "1.1.2"
@@ -2304,7 +2323,7 @@ css-loader@^0.28.7:
     postcss-value-parser "^3.3.0"
     source-list-map "^2.0.0"
 
-css-select@^1.1.0:
+css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
   dependencies:
@@ -2665,6 +2684,10 @@ directory-tree@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/directory-tree/-/directory-tree-2.0.0.tgz#c0a5fa0d642a1b1b7d10351b3c1db429770d8946"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -2701,7 +2724,7 @@ dom-converter@~0.1:
   dependencies:
     utila "~0.3"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
   dependencies:
@@ -2902,6 +2925,53 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+  dependencies:
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.6.0"
+
+enzyme-to-json@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz#ede45938fb309cd87ebd4386f60c754525515a07"
+  dependencies:
+    lodash "^4.17.4"
+
+enzyme@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
+  dependencies:
+    cheerio "^1.0.0-rc.2"
+    function.prototype.name "^1.0.3"
+    has "^1.0.1"
+    is-boolean-object "^1.0.0"
+    is-callable "^1.1.3"
+    is-number-object "^1.0.3"
+    is-string "^1.0.4"
+    is-subset "^0.1.1"
+    lodash "^4.17.4"
+    object-inspect "^1.5.0"
+    object-is "^1.0.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
+    object.values "^1.0.4"
+    raf "^3.4.0"
+    rst-selector-parser "^2.2.3"
+
 errno@^0.1.3:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
@@ -2920,7 +2990,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.7.0:
+es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
   dependencies:
@@ -3747,9 +3817,17 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
+function.prototype.name@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.0.tgz#8bd763cc0af860a859cc5d49384d74b932cd2327"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    is-callable "^1.1.3"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -4064,6 +4142,10 @@ has-symbol-support-x@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.1.tgz#66ec2e377e0c7d7ccedb07a3a84d77510ff1bc4c"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
@@ -4252,7 +4334,7 @@ html-webpack-plugin@^2.30.1:
     pretty-error "^2.0.2"
     toposort "^1.0.0"
 
-htmlparser2@^3.9.0:
+htmlparser2@^3.9.0, htmlparser2@^3.9.1:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
   dependencies:
@@ -4540,6 +4622,10 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-boolean-object@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.0.0.tgz#98f8b28030684219a95f375cfbd88ce3405dff93"
+
 is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -4695,6 +4781,10 @@ is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
 
+is-number-object@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.3.tgz#f265ab89a9f445034ef6aff15a8f00b00f551799"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -4792,6 +4882,14 @@ is-root@1.0.0:
 is-stream@1.1.0, is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
 
 is-svg@^2.0.0:
   version "2.1.0"
@@ -5395,6 +5493,10 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -5407,7 +5509,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
@@ -5752,6 +5854,15 @@ ncname@1.0.x:
   dependencies:
     xml-char-classes "^1.0.0"
 
+nearley@^2.7.10:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.13.0.tgz#6e7b0f4e68bfc3e74c99eaef2eda39e513143439"
+  dependencies:
+    nomnom "~1.6.2"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
@@ -5841,6 +5952,13 @@ node-pre-gyp@^0.6.39:
 node-version@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/node-version/-/node-version-1.1.0.tgz#f437d7ba407e65e2c4eaef8887b1718ba523d4f0"
+
+nomnom@~1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.6.2.tgz#84a66a260174408fc5b77a18f888eccc44fb6971"
+  dependencies:
+    colors "0.5.x"
+    underscore "~1.4.4"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5941,7 +6059,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-keys@^1.0.8:
+object-inspect@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.5.0.tgz#9d876c11e40f485c79215670281b767488f9bfe3"
+
+object-is@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
@@ -5950,6 +6076,24 @@ object-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
   dependencies:
     isobject "^3.0.0"
+
+object.assign@^4.0.4, object.assign@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.1"
+    has-symbols "^1.0.0"
+    object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -5963,6 +6107,15 @@ object.pick@^1.3.0:
   resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
   dependencies:
     isobject "^3.0.1"
+
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.1"
@@ -6162,6 +6315,12 @@ parse-passwd@^1.0.0:
 parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  dependencies:
+    "@types/node" "*"
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -6821,6 +6980,17 @@ raf@^3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -6945,6 +7115,19 @@ react-html-parser@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-html-parser/-/react-html-parser-2.0.2.tgz#6dbe1ddd2cebc1b34ca15215158021db5fc5685e"
   dependencies:
     htmlparser2 "^3.9.0"
+
+react-is@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.1.tgz#ee66e6d8283224a83b3030e110056798488359ba"
+
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react-router-dom@^4.2.2:
   version "4.2.2"
@@ -7078,6 +7261,15 @@ react-syntax-highlighter@^7.0.0:
     lowlight "~1.9.1"
     prismjs "^1.8.4"
     refractor "^2.0.0"
+
+react-test-renderer@^16.0.0-0:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.1.tgz#d9257936d8535bd40f57f3d5a84e7b0452fb17f2"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.1"
 
 react-universal-component@^2.8.1:
   version "2.8.4"
@@ -7474,6 +7666,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -7567,7 +7766,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -8508,6 +8707,10 @@ unbzip2-stream@^1.0.9:
     buffer "^3.0.1"
     through "^2.3.6"
 
+underscore@~1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
+
 unified@^6.1.6:
   version "6.1.6"
   resolved "https://registry.yarnpkg.com/unified/-/unified-6.1.6.tgz#5ea7f807a0898f1f8acdeefe5f25faa010cc42b1"
@@ -8584,6 +8787,21 @@ update-notifier@2.3.0:
     chalk "^2.0.1"
     configstore "^3.0.0"
     import-lazy "^2.1.0"
+    is-installed-globally "^0.1.0"
+    is-npm "^1.0.0"
+    latest-version "^3.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^3.0.0"
+
+update-notifier@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-2.4.0.tgz#f9b4c700fbfd4ec12c811587258777d563d8c866"
+  dependencies:
+    boxen "^1.2.1"
+    chalk "^2.0.1"
+    configstore "^3.0.0"
+    import-lazy "^2.1.0"
+    is-ci "^1.0.10"
     is-installed-globally "^0.1.0"
     is-npm "^1.0.0"
     latest-version "^3.0.0"


### PR DESCRIPTION
This pull request decouples error handling and UI  from the `<Router />` and moves it into the `<ErrorWrapper />` . Introduces additional prop on the `<Router />`, `showErrorsInProduction` which when set to `true` to enable the debug/error page in production. Defaults to `false`, error page does not appear in production.


This pull request fixes #553 and introduces some tests arounds the changes.