### PR TITLE
Use correct build stage name in jsLoader

### DIFF
--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -6,7 +6,7 @@ export default function ({ config, stage }) {
       {
         loader: 'babel-loader',
         options: {
-          cacheDirectory: stage !== 'production',
+          cacheDirectory: stage !== 'prod',
         },
       },
     ],


### PR DESCRIPTION
`production` is not one of the valid stages, according to [docs](https://github.com/nozzle/react-static/blob/5fe177934381da6a79e15d4c5d96ef5d77a6a35d/docs/config.md#webpack):

> `args.stage` is a string of either `prod`, `dev` or `node`, denoting which stage react-static is building for.