### PR TITLE
Fix error caused by rebuild routes docs example

### DIFF
--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -63,7 +63,7 @@ reloadRoutes()
 
 // Reload when files change
 import chokidar from 'chokidar'
-chokidar.watch('./docs').on('all', reloadRoutes)
+chokidar.watch('./docs').on('all', () => reloadRoutes())
 
 // Reload from API or CMS event
 YourFavoriteCMS.subscribe(reloadRoutes)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The current example of the `rebuildRoutes` method in the [node api docs](https://react-static.js.org/node-api#rebuildroutes) gives an error: "TypeError: paths.map is not a function". I haven't dug in to investigate why this error is caused but it seems to be caused by the parameters chokidar passes to the function.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed docs to fix the error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Save time for other people who follow the docs example and will probably encounter the error.

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->
<img width="725" alt="screen shot 2018-04-16 at 11 19 00" src="https://user-images.githubusercontent.com/5038459/38789958-0b1b286e-4168-11e8-9212-7b0034ccc35b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] My changes have tests around them
