### PR TITLE
Added new configuration option 'disableRoutePrefixing'

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -23,6 +23,7 @@ A `static.config.js` file is optional, but recommended at your project root to u
 * [outputFileRate](#outputfilerate)
 * [prefetchRate](#prefetchrate)
 * [disableRouteInfoWarning](#disableRouteInfoWarning)
+* [disableRoutePrefixing](#disableRoutePrefixing)
 
 ### `getRoutes`
 
@@ -475,5 +476,16 @@ An optional `Boolean`. Set to `true` to disable warnings during development when
 // static.config.js
 export default {
   disableRouteInfoWarning: true
+}
+```
+
+### `disableRoutePrefixing`
+
+An optional `Boolean`. Set to `true` to disable prefixing link href values and the browser history with `config.siteData`.
+
+```javascript
+// static.config.js
+export default {
+  disableRoutePrefixing: true
 }
 ```

--- a/src/client/components/Router.js
+++ b/src/client/components/Router.js
@@ -156,7 +156,7 @@ export default class Router extends React.Component {
           resolvedHistory = createHashHistory()
         } else {
           const options = process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING ? {} :
-              { basename: process.env.REACT_STATIC_BASEPATH }
+            { basename: process.env.REACT_STATIC_BASEPATH }
           resolvedHistory = createBrowserHistory(options)
         }
       }

--- a/src/client/components/Router.js
+++ b/src/client/components/Router.js
@@ -155,9 +155,9 @@ export default class Router extends React.Component {
         } else if (type === 'hash') {
           resolvedHistory = createHashHistory()
         } else {
-          resolvedHistory = createBrowserHistory({
-            basename: process.env.REACT_STATIC_BASEPATH,
-          })
+          const options = process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING ? {} :
+              { basename: process.env.REACT_STATIC_BASEPATH }
+          resolvedHistory = createBrowserHistory(options)
         }
       }
       global.__reactStaticRouterHistory = resolvedHistory
@@ -174,7 +174,7 @@ export default class Router extends React.Component {
           history={resolvedHistory}
           location={staticURL}
           context={context}
-          basename={process.env.REACT_STATIC_BASEPATH}
+          basename={process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING ? '' : process.env.REACT_STATIC_BASEPATH}
           {...rest}
       >
           <RouterScroller

--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -90,9 +90,8 @@ export const getRouteInfo = async (path, { priority } = {}) => {
       if (!inflightRouteInfo[path]) {
         inflightRouteInfo[path] = requestPool.add(() =>
           axios.get(
-            `${process.env.REACT_STATIC_PUBLIC_PATH}${pathJoin(
-              path,
-              `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`
+            `${process.env.REACT_STATIC_PUBLIC_PATH}${REACT_STATIC_DISABLE_ROUTE_PREFIXING ? '' : 
+                pathJoin(path, `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`
             )}`
           )
         )

--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -90,8 +90,9 @@ export const getRouteInfo = async (path, { priority } = {}) => {
       if (!inflightRouteInfo[path]) {
         inflightRouteInfo[path] = requestPool.add(() =>
           axios.get(
-            `${process.env.REACT_STATIC_PUBLIC_PATH}${REACT_STATIC_DISABLE_ROUTE_PREFIXING ? '' : 
-                pathJoin(path, `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`
+            `${process.env.REACT_STATIC_PUBLIC_PATH}${pathJoin(
+              path,
+              `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`
             )}`
           )
         )

--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -125,6 +125,7 @@ export default function getConfig (customConfig, { watch } = {}) {
       renderToHtml: (render, Comp) => render(<Comp />),
       prefetchRate: 3,
       disableRouteInfoWarning: false,
+      disableRoutePrefixing: false,
       outputFileRate: 10,
       // Config Overrides
       ...config,
@@ -143,6 +144,7 @@ export default function getConfig (customConfig, { watch } = {}) {
     // Set env variables to be used client side
     process.env.REACT_STATIC_PREFETCH_RATE = finalConfig.prefetchRate
     process.env.REACT_STATIC_DISABLE_ROUTE_INFO_WARNING = finalConfig.disableRouteInfoWarning
+    process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING = finalConfig.disableRoutePrefixing
 
     return finalConfig
   }


### PR DESCRIPTION
## Description
Disabling the route prefix will allow the usage of a base URL that will apply to most resource GET requests but not history and route URL requests.

An example use case would be `mysite.com/us/en/blog` which would request for `/us/en/blog/index.html` and `/us/en/blog/routeInfo.json`. But allowing other root resources to be at a different baseUrl such as `my-blog`. Loading the `mysite.com/us/en/blog` would request for `/my-blog/bootstrap.981e38c5.js`

## Changes/Tasks
- [ ] Added new boolean setting `config.disableRoutePrefixing`

## Motivation and Context
https://github.com/nozzle/react-static/issues/571

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
- [ x ] New feature (non-breaking change which adds functionality)

## Checklist:
- [ x ] My change requires a change to the documentation.
  - [ x ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
