### PR TITLE
Don't extract CSS in webpack during node stage

### DIFF
--- a/src/static/webpack/rules/cssLoader.js
+++ b/src/static/webpack/rules/cssLoader.js
@@ -3,46 +3,46 @@ import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import ExtractCssChunks from 'extract-css-chunks-webpack-plugin'
 import postcssFlexbugsFixes from 'postcss-flexbugs-fixes'
 
-export default function ({ config, stage }) {
-  if (stage === 'dev') {
-    return {
-      test: /\.css$/,
-      use: [
-        'style-loader',
-        {
-          loader: 'css-loader',
-          options: {
-            sourceMap: true,
-            importLoaders: 1,
-          },
-        },
-        {
-          loader: 'postcss-loader',
-          options: {
-            // Necessary for external CSS imports to work
-            // https://github.com/facebookincubator/create-react-app/issues/2677
-            sourceMap: true,
-            ident: 'postcss',
-            plugins: () => [
-              postcssFlexbugsFixes,
-              autoprefixer({
-                browsers: [
-                  '>1%',
-                  'last 4 versions',
-                  'Firefox ESR',
-                  'not ie < 9', // React doesn't support IE8 anyway
-                ],
-                flexbox: 'no-2009',
-              }),
+export default function ({ config, stage, isNode }) {
+  let cssLoader = [
+    {
+      loader: 'css-loader',
+      options: {
+        importLoaders: 1,
+        minimize: stage === 'prod',
+        sourceMap: false,
+      },
+    },
+    {
+      loader: 'postcss-loader',
+      options: {
+        // Necessary for external CSS imports to work
+        // https://github.com/facebookincubator/create-react-app/issues/2677
+        sourceMap: true,
+        ident: 'postcss',
+        plugins: () => [
+          postcssFlexbugsFixes,
+          autoprefixer({
+            browsers: [
+              '>1%',
+              'last 4 versions',
+              'Firefox ESR',
+              'not ie < 9', // React doesn't support IE8 anyway
             ],
-          },
-        },
-      ],
-    }
-  }
-  return {
-    test: /\.css$/,
-    loader: (config.extractCssChunks ? ExtractCssChunks : ExtractTextPlugin).extract({
+            flexbox: 'no-2009',
+          }),
+        ],
+      },
+    },
+  ]
+
+  if (stage === 'dev') {
+    cssLoader = ['style-loader'].concat(cssLoader)
+  } else if (!isNode) {
+    cssLoader = (config.extractCssChunks
+      ? ExtractCssChunks
+      : ExtractTextPlugin
+    ).extract({
       fallback: {
         loader: 'style-loader',
         options: {
@@ -50,37 +50,12 @@ export default function ({ config, stage }) {
           hmr: false,
         },
       },
-      use: [
-        {
-          loader: 'css-loader',
-          options: {
-            importLoaders: 1,
-            minimize: true,
-            sourceMap: false,
-          },
-        },
-        {
-          loader: 'postcss-loader',
-          options: {
-            // Necessary for external CSS imports to work
-            // https://github.com/facebookincubator/create-react-app/issues/2677
-            sourceMap: true,
-            ident: 'postcss',
-            plugins: () => [
-              postcssFlexbugsFixes,
-              autoprefixer({
-                browsers: [
-                  '>1%',
-                  'last 4 versions',
-                  'Firefox ESR',
-                  'not ie < 9', // React doesn't support IE8 anyway
-                ],
-                flexbox: 'no-2009',
-              }),
-            ],
-          },
-        },
-      ],
-    }),
+      use: cssLoader,
+    })
+  }
+
+  return {
+    test: /\.css$/,
+    loader: cssLoader,
   }
 }

--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -16,7 +16,9 @@ export default function ({ config, isNode }) {
   } = config.paths
 
   config.publicPath = process.env.REACT_STATIC_STAGING
-    ? `${config.stagingSiteRoot}/${config.stagingBasePath ? `${config.stagingBasePath}/` : ''}`
+    ? `${config.stagingSiteRoot}/${
+      config.stagingBasePath ? `${config.stagingBasePath}/` : ''
+    }`
     : `${config.siteRoot}/${config.basePath ? `${config.basePath}/` : ''}`
 
   process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
@@ -38,12 +40,16 @@ export default function ({ config, isNode }) {
     externals: isNode
       ? [
         nodeExternals({
-          whitelist: ['react-universal-component', 'webpack-flush-chunks', 'react-static-routes'],
+          whitelist: [
+            'react-universal-component',
+            'webpack-flush-chunks',
+            'react-static-routes',
+          ],
         }),
       ]
       : [],
     module: {
-      rules: rules({ config, stage: 'prod' }),
+      rules: rules({ config, stage: 'prod', isNode }),
     },
     resolve: {
       alias: config.preact
@@ -63,15 +69,16 @@ export default function ({ config, isNode }) {
     },
     plugins: [
       new webpack.EnvironmentPlugin(process.env),
-      config.extractCssChunks ?
-        new ExtractCssChunks() :
-        new ExtractTextPlugin({
-          filename: getPath => {
-            process.env.extractedCSSpath = getPath('styles.[hash:8].css')
-            return process.env.extractedCSSpath
-          },
-          allChunks: true,
-        }),
+      !isNode &&
+        (config.extractCssChunks
+          ? new ExtractCssChunks()
+          : new ExtractTextPlugin({
+            filename: getPath => {
+              process.env.extractedCSSpath = getPath('styles.[hash:8].css')
+              return process.env.extractedCSSpath
+            },
+            allChunks: true,
+          })),
       new CaseSensitivePathsPlugin(),
       !isNode &&
         new webpack.optimize.CommonsChunkPlugin({
@@ -82,7 +89,9 @@ export default function ({ config, isNode }) {
         new webpack.optimize.LimitChunkCountPlugin({
           maxChunks: 1,
         }),
-      !isNode && !process.env.REACT_STATIC_DEBUG && new webpack.optimize.UglifyJsPlugin(),
+      !isNode &&
+        !process.env.REACT_STATIC_DEBUG &&
+        new webpack.optimize.UglifyJsPlugin(),
       // !isNode &&
       //   new SWPrecacheWebpackPlugin({
       //     cacheId: config.siteName || 'my-site-name',


### PR DESCRIPTION
Currently in 5.8.1, CSS files are getting extracted in both node and prod stages. This results in two identical CSS files.

This PR removes `ExtractCssChunks` and  `ExtractTextPlugin` when in the node stage.

## How to reproduce

Run `yarn run text-sample-build` and notice it generates two CSS files with identical content.

![image](https://user-images.githubusercontent.com/7423098/39011963-9eccdeb4-43d8-11e8-9dc7-1eb2c35b4201.png)

![image](https://user-images.githubusercontent.com/7423098/39011999-bc41af2e-43d8-11e8-9b8e-b69ac379dd47.png)

![image](https://user-images.githubusercontent.com/7423098/39011997-b5e9402e-43d8-11e8-9c97-1ae31c4eff17.png)