### PR TITLE
Checking config.disableRoutePrefixing to get correct routeInfo

### DIFF
--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -20,6 +20,9 @@ export default function ({ config, isNode }) {
     : `${config.siteRoot}/${config.basePath ? `${config.basePath}/` : ''}`
 
   process.env.REACT_STATIC_PUBLIC_PATH = config.publicPath
+  process.env.REACT_STATIC_SITE_ROOT = process.env.REACT_STATIC_STAGING
+    ? config.stagingSiteRoot
+    : config.siteRoot
   process.env.REACT_STATIC_BASEPATH = process.env.REACT_STATIC_STAGING
     ? config.stagingBasePath
     : config.basePath


### PR DESCRIPTION
Follow up fix to https://github.com/nozzle/react-static/pull/572

## Description
If the `config.disableRoutePrefixing` flag is set then requests for `routeInfo.json` must also ignore baseRoute prefixing to ensure the correct file is retrieved. This file is stored directly next to the route so the prefixing must mirror that of routes.

## Changes/Tasks
- [ ] Checking REACT_STATIC_DISABLE_ROUTE_PREFIXING to determine the correct path before making an Axios get request to retrieve `routeInfo.json`

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
