### PR TITLE
Correct URL in sitemap when `config.disableRoutePrefixing` is used

### DIFF
--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -81,7 +81,7 @@ export const getRouteInfo = async (path, { priority } = {}) => {
       const routeInfoRoot = (process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING
         ? process.env.REACT_STATIC_SITE_ROOT
         : process.env.REACT_STATIC_PUBLIC_PATH) || '/'
-      const getPath = `${routeInfoRoot}${pathJoin(path, `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`)}`
+      const getPath = `${routeInfoRoot}/${pathJoin(path, `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`)}`
 
       if (priority) {
         // In production, request from route's routeInfo.json

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -455,7 +455,7 @@ export async function buildXMLandRSS ({ config }) {
   const prefixPath = config.disableRoutePrefixing ? siteRoot : config.publicPath
   const xml = generateXML({
     routes: config.routes.filter(d => !d.is404).map(route => ({
-      permalink: `${prefixPath}${pathJoin(route.path)}`,
+      permalink: `${prefixPath}/${pathJoin(route.path)}`,
       lastModified: '',
       priority: 0.5,
       ...route,

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -448,12 +448,14 @@ export const exportRoutes = async ({ config, clientStats }) => {
 }
 
 export async function buildXMLandRSS ({ config }) {
-  if (!config.siteRoot) {
+  const siteRoot = process.env.REACT_STATIC_STAGING ? config.stagingSiteRoot : config.siteRoot
+  if (!siteRoot) {
     return
   }
+  const prefixPath = config.disableRoutePrefixing ? siteRoot : config.publicPath
   const xml = generateXML({
     routes: config.routes.filter(d => !d.is404).map(route => ({
-      permalink: `${config.publicPath}${pathJoin(route.path)}`,
+      permalink: `${prefixPath}${pathJoin(route.path)}`,
       lastModified: '',
       priority: 0.5,
       ...route,


### PR DESCRIPTION
## Description
When the `config.disableRoutePrefixing` flag is used the `basePath` should not be used to preface path links. The sitemap should mirror the behavior.

## Changes/Tasks
- [ ] Checking if staging to determine the correct siteRoot to use in the `sitemap.xml`
- [ ] Generating correct URL in sitemap if `config.disableRoutePrefixing` is used

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
