### PR TITLE
A possible fix for #539

### DIFF
--- a/src/client/components/RouteData.js
+++ b/src/client/components/RouteData.js
@@ -71,7 +71,7 @@ const RouteData = withRouter(
       let allProps
 
       // Attempt to get routeInfo from window (first-load on client)
-      if (typeof window !== 'undefined' && window.__routeInfo && window.__routeInfo.path === path) {
+      if (typeof window !== 'undefined' && window.__routeInfo && (window.__routeInfo.path === path || window.__routeInfo.path === '404')) {
         loaded = true // Since these are synchronous, override loading to true
         allProps = window.__routeInfo.allProps
       }


### PR DESCRIPTION
This is more like a work-a-round. The root-cause however is the prop `is404` being `undefined` here.

This does hover resolve my issue with the built 404 page.