### PR TITLE
Compare `process.env` variables as strings rather than booleans.

### DIFF
--- a/src/client/components/Router.js
+++ b/src/client/components/Router.js
@@ -139,6 +139,7 @@ export default class Router extends React.Component {
     } = this.props
     const { staticURL } = this.context
     const context = staticURL ? {} : undefined
+    const disableRoutePrefixing = process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING === 'true'
 
     const { ready } = this.state
 
@@ -158,7 +159,7 @@ export default class Router extends React.Component {
         } else if (type === 'hash') {
           resolvedHistory = createHashHistory()
         } else {
-          const options = process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING
+          const options = disableRoutePrefixing
             ? {}
             : { basename: process.env.REACT_STATIC_BASEPATH }
           resolvedHistory = createBrowserHistory(options)
@@ -179,7 +180,7 @@ export default class Router extends React.Component {
           location={staticURL}
           context={context}
           basename={
-            process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING
+            disableRoutePrefixing
               ? ''
               : process.env.REACT_STATIC_BASEPATH
           }

--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -81,7 +81,7 @@ export const getRouteInfo = async (path, { priority } = {}) => {
       routeInfo = data
     } else {
       const routeInfoRoot =
-        (process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING
+        (process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING === 'true'
           ? process.env.REACT_STATIC_SITE_ROOT
           : process.env.REACT_STATIC_PUBLIC_PATH) || '/'
       const getPath = `${routeInfoRoot}${pathJoin(

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -177,7 +177,7 @@ export const exportRoutes = async ({ config, clientStats }) => {
   const htmlProgress = Bar(config.routes.length)
   console.time(chalk.green('=> [\u2713] HTML Exported'))
 
-  const basePath = process.env.REACT_STATIC_STAGING ? config.stagingBasePath : config.basePath
+  const basePath = process.env.REACT_STATIC_STAGING === 'true' ? config.stagingBasePath : config.basePath
   const hrefReplace = new RegExp(
     `(href=["'])\\/(${basePath ? `${basePath}\\/` : ''})?([^\\/])`,
     'gm'
@@ -445,7 +445,7 @@ export const exportRoutes = async ({ config, clientStats }) => {
 }
 
 export async function buildXMLandRSS ({ config }) {
-  const siteRoot = process.env.REACT_STATIC_STAGING ? config.stagingSiteRoot : config.siteRoot
+  const siteRoot = process.env.REACT_STATIC_STAGING === 'true' ? config.stagingSiteRoot : config.siteRoot
   if (!siteRoot) {
     return
   }


### PR DESCRIPTION
fixes #593 

## Description

We are setting `process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING` to a boolean value here: https://github.com/nozzle/react-static/blob/master/src/static/getConfig.js#L153

But node converts this to a string by default.

Thus this code does not work as expected: https://github.com/nozzle/react-static/blob/master/src/client/methods.js#L84

`process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING` is "false" which evaluates to true
