### PR TITLE
Don't include test files when creating a build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "react-static": "./bin/react-static"
   },
   "scripts": {
-    "build": "rimraf lib && rimraf node_modules/react-static && babel src --out-dir lib && yarn prepGitignore",
-    "start": "rimraf lib && rimraf node_modules/react-static && babel -w src --out-dir lib",
+    "build": "rimraf lib && rimraf node_modules/react-static && babel src --out-dir lib --ignore '**/__tests__/*' && yarn prepGitignore",
+    "start": "rimraf lib && rimraf node_modules/react-static && babel -w src --out-dir lib --ignore '**/__tests__/*'",
     "postpublish": "git push --tags",
     "prepublishOnly": "yarn build && yarn test",
     "publishNext": "yarn publish --tag next",


### PR DESCRIPTION
Test files shouldn't be included in the built `/lib` directory. 

This PR ignores `**/__tests__/*` when running `yarn build` or `yarn start`.