### PR TITLE
Adds Automated building of all examples

### DIFF
--- a/testExamplesBuild.js
+++ b/testExamplesBuild.js
@@ -1,0 +1,34 @@
+const { execSync } = require('child_process')
+const fs = require('fs')
+const chalk = require('chalk')
+
+const exampleToError = new Map()
+
+fs.readdirSync('./examples').forEach(
+  file => {
+    process.chdir(`./examples/${file}`)
+    try {
+      console.log(`${chalk.green(`Building ${file}`)}`)
+      execSync('yarn install')
+      execSync('rm -rf node_modules/react-static')
+      execSync('ln -s -f ../../../ ./node_modules/react-static')
+      execSync('../../bin/react-static build')
+    } catch (er) {
+      console.log(`${chalk.red(`Failed ${file}`)}`)
+      exampleToError.set(file, er.stdout.toString('utf-8'))
+    } finally {
+      process.chdir('../../')
+    }
+  }
+)
+
+
+for (const [example, errorMessage] of exampleToError.entries()) {
+  console.log(`${chalk.bold.black.bgRed(`Error building ${example}`)}`)
+  console.log(errorMessage)
+}
+
+if (exampleToError.size > 0) {
+  process.exit(1)
+}
+


### PR DESCRIPTION
Adds a script to build all the examples in an automated manner.

## Description
testBuildsExample.js is a script that builds all the examples.

## Changes/Tasks
- [x] Added code

## Motivation and Context
It is possible that changes to the react-static library can cause some of the examples that are shipped with the library to stop working. There is no easy way for a developer to check if their changes are breaking any of the templates that react-static supports. This script builds every example and if any example fails to build it prints out the error and exits with an error code.

TODO:
- integrate this with travis

## Types of changes
- [x]  Added new test
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
