### PR TITLE
Use exact root routes in examples Nav

### DIFF
--- a/examples/algolia/src/App.js
+++ b/examples/algolia/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
         <Link to="/search">Search</Link>

--- a/examples/animated-routes/src/App.js
+++ b/examples/animated-routes/src/App.js
@@ -114,7 +114,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/apollo-redux/src/App.js
+++ b/examples/apollo-redux/src/App.js
@@ -17,7 +17,7 @@ const App = () => (
       <Router>
         <div>
           <nav>
-            <Link to="/">Home</Link>
+            <Link exact to="/">Home</Link>
             <Link to="/about">About</Link>
             <Link to="/blog">Blog</Link>
           </nav>

--- a/examples/apollo/src/App.js
+++ b/examples/apollo/src/App.js
@@ -14,7 +14,7 @@ const App = () => (
     <Router>
       <div>
         <nav>
-          <Link to="/">Home</Link>
+          <Link exact to="/">Home</Link>
           <Link to="/about">About</Link>
           <Link to="/blog">Blog</Link>
         </nav>

--- a/examples/basic-prismic/src/App.js
+++ b/examples/basic-prismic/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/basic/src/App.js
+++ b/examples/basic/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/cordova/src/App.js
+++ b/examples/cordova/src/App.js
@@ -50,7 +50,7 @@ const App = () => (
   <Router type="hash">
     <AppStyles>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/geolocation">Geolocation</Link>
       </nav>
       <div className="content">

--- a/examples/custom-routing/src/App.js
+++ b/examples/custom-routing/src/App.js
@@ -13,7 +13,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about/">About</Link>
         <Link to="/blog/">Blog</Link>
       </nav>

--- a/examples/dynamic-imports/src/App.js
+++ b/examples/dynamic-imports/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/firebase-auth/src/App.js
+++ b/examples/firebase-auth/src/App.js
@@ -12,7 +12,7 @@ const App = withAuthentication(() => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/glamorous/src/App.js
+++ b/examples/glamorous/src/App.js
@@ -37,7 +37,7 @@ const App = () => (
   <Router>
     <AppStyles>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/markdown/src/App.js
+++ b/examples/markdown/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/netlifycms/src/App.js
+++ b/examples/netlifycms/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/non-static-routing/src/App.js
+++ b/examples/non-static-routing/src/App.js
@@ -14,7 +14,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/non-static">Non-Static Route</Link>
         <Link to="/i-dont-match-any-route">Non-Matching Route</Link>
       </nav>

--- a/examples/pagination/src/App.js
+++ b/examples/pagination/src/App.js
@@ -49,7 +49,7 @@ const App = () => (
   <Router>
     <AppStyles>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
         <Link to="/users">Users</Link>

--- a/examples/preact/src/App.js
+++ b/examples/preact/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/redux/src/App.js
+++ b/examples/redux/src/App.js
@@ -13,7 +13,7 @@ const App = () => (
     <Router>
       <div>
         <nav>
-          <Link to="/">Home</Link>
+          <Link exact to="/">Home</Link>
           <Link to="/about">About</Link>
           <Link to="/blog">Blog</Link>
         </nav>

--- a/examples/sass/src/App.js
+++ b/examples/sass/src/App.js
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/styled-components/src/App.js
+++ b/examples/styled-components/src/App.js
@@ -47,7 +47,7 @@ const App = () => (
   <Router>
     <AppStyles>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/styled-jsx/src/App.js
+++ b/examples/styled-jsx/src/App.js
@@ -9,7 +9,7 @@ export default () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>

--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -10,7 +10,7 @@ const App = () => (
   <Router>
     <div>
       <nav>
-        <Link to="/">Home</Link>
+        <Link exact to="/">Home</Link>
         <Link to="/about">About</Link>
         <Link to="/blog">Blog</Link>
       </nav>


### PR DESCRIPTION
Update Example templates

## Description
The example nav routes call `<Link to="/">Home</Link>`, which causes the routes to match root AND all child pages. This fixes this so Nav correctly states aria-current states for the current navigation items across many examples.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code

## Motivation and Context
Making it easier to spin up sample projects

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
