### PR TITLE
Report errors when building configuration

### DIFF
--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -198,6 +198,7 @@ const buildConfigFromPath = configPath => {
     const config = require(configPath).default
     return buildConfigation(config)
   } catch (err) {
+    console.error(err)
     return {}
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds logging of compiler errors during requiring of config file (like `static.config.js`)

## Changes/Tasks

- [x] Added `console.error` statement to `catch` block of `buildConfigFromPath`

## Motivation and Context

When `static.config.js` contains any compiler errors causing `require(configPath).default` to fail, `react-static build` fails with a rather unhelpful error message (since it tries to continues with an empty configuration)
``` TypeError: Cannot read property 'DIST' of undefined```
This makes debugging errors in `static.config.js` hard.

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
