### PR TITLE
fix cache busting for routeInfo.json via route param

### DIFF
--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -84,10 +84,14 @@ export const getRouteInfo = async (path, { priority } = {}) => {
         (process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING === 'true'
           ? process.env.REACT_STATIC_SITE_ROOT
           : process.env.REACT_STATIC_PUBLIC_PATH) || '/'
+      const cacheBuster = 
+        process.env.REACT_STATIC_CACHE_BUST 
+        ? `?${process.env.REACT_STATIC_CACHE_BUST}` 
+        : ''     
       const getPath = `${routeInfoRoot}${pathJoin(
-        path,
-        `routeInfo.json?${process.env.REACT_STATIC_CACHE_BUST}`
-      )}`
+        path, 
+        'routeInfo.json'
+      )}${cacheBuster}`
 
       if (priority) {
         // In production, request from route's routeInfo.json

--- a/src/client/methods.js
+++ b/src/client/methods.js
@@ -84,12 +84,12 @@ export const getRouteInfo = async (path, { priority } = {}) => {
         (process.env.REACT_STATIC_DISABLE_ROUTE_PREFIXING === 'true'
           ? process.env.REACT_STATIC_SITE_ROOT
           : process.env.REACT_STATIC_PUBLIC_PATH) || '/'
-      const cacheBuster = 
-        process.env.REACT_STATIC_CACHE_BUST 
-        ? `?${process.env.REACT_STATIC_CACHE_BUST}` 
-        : ''     
+      const cacheBuster =
+        process.env.REACT_STATIC_CACHE_BUST
+          ? `?${process.env.REACT_STATIC_CACHE_BUST}`
+          : ''
       const getPath = `${routeInfoRoot}${pathJoin(
-        path, 
+        path,
         'routeInfo.json'
       )}${cacheBuster}`
 


### PR DESCRIPTION
prevent REACT_STATIC_CACHE_BUST from getting discarded by pathJoin

## Description
pathJoin removes the get parameters from the path and thus prevents process.env.REACT_STATIC_CACHE_BUST from having any effect. This change pulls the cache busting param outside of pathJoin and makes sure it survives into the build.

## Changes/Tasks
- [x] Changed code

## Motivation and Context
This is needed for cache busting of routeInfo.json files. Without this, no method exists for cache busting of those files.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
