### PR TITLE
fix for issue#631

### DIFF
--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -83,7 +83,7 @@ export default {
         ],
       },
     ]
-    // You might need to make the file name universal
+    // FIXME: You might need to make the file name universal
     config.plugins = [new ExtractTextPlugin('index.css')]
     return config
   },

--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -84,7 +84,7 @@ export default {
       },
     ]
     // FIXME: You might need to make the file name universal
-    config.plugins = [new ExtractTextPlugin('index.css')]
+    config.plugins = [new ExtractTextPlugin('app.css')]
     return config
   },
 }

--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -84,7 +84,7 @@ export default {
       },
     ]
     // FIXME: You might need to make the file name universal
-    config.plugins = [new ExtractTextPlugin('app.css')]
+    config.plugins.push(new ExtractTextPlugin('app.css'))
     return config
   },
 }

--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -4,6 +4,9 @@ import path from 'path'
 // Paths Aliases defined through tsconfig.json
 const typescriptWebpackPaths = require('./webpack.config.js')
 
+/** Load extract-text-webpack-plugin for proper implement as the example shows: {@link https://github.com/webpack-contrib/extract-text-webpack-plugin#usage} */
+const ExtractTextPlugin = require('extract-text-webpack-plugin')
+
 export default {
   entry: path.join(__dirname, 'src', 'index.tsx'),
   getSiteData: () => ({
@@ -68,11 +71,20 @@ export default {
               },
             ],
           },
-          defaultLoaders.cssLoader,
+          {
+            test: /\.css$/,
+            use: ExtractTextPlugin.extract({
+              fallback: 'style-loader',
+              use: 'css-loader',
+            }),
+          },
+          // defaultLoaders.cssLoader,
           defaultLoaders.fileLoader,
         ],
       },
     ]
+    // You might need to make the file name universal
+    config.plugins = [new ExtractTextPlugin('index.css')]
     return config
   },
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've figured out the workaround to make `yarn build` work in react-static@5.9.7 with typescript, otherwise it returns: 
```
Module build failed: Error: "extract-text-webpack-plugin" loader is used without the corresponding plugin, refer to https://github.com/webpack/extract-text-webpack-plugin for the usage example
```

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
I referred briefly on [extract-text-webpack-plugin example](https://github.com/webpack-contrib/extract-text-webpack-plugin#usage), added a few lines. You can easily figure out what's going on at a glance I believe.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's an [open issue](https://github.com/nozzle/react-static/issues/631)

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
