### PR TITLE
Sitemap.xml may contain invalid characters

### DIFF
--- a/src/static/__tests__/__snapshots__/buildXML.test.js.snap
+++ b/src/static/__tests__/__snapshots__/buildXML.test.js.snap
@@ -4,6 +4,8 @@ exports[`generateXML should return the XML for route 1`] = `"<?xml version=\\"1.
 
 exports[`generateXML when noindex defined and route is 404 should return a the XML with \`/best-lib/\` route  1`] = `"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\"><url><loc>/blog/path/to/article/</loc><priority>0.5</priority></url></urlset>"`;
 
+exports[`makeGenerateRouteXML should use encoding for XML-values 1`] = `"<url><loc>/this-&amp;-that/&quot;官话&quot;-is-chinese-&apos;ру́сский язы́к&apos;-is-russian/</loc><priority>0.5</priority></url>"`;
+
 exports[`makeGenerateRouteXML when custom properties are defined should return the XML for route 1`] = `"<url><loc>/blog/path/to/somewhere/</loc><lastmod>10/10/2010</lastmod><priority>0.2</priority></url>"`;
 
 exports[`when custom properties are defined should return the XML site 1`] = `"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?><urlset xmlns=\\"http://www.sitemaps.org/schemas/sitemap/0.9\\"><url><loc>www.example.com/path/to/somewhere/</loc><lastmod>10/10/2010</lastmod><priority>0.2</priority></url></urlset>"`;

--- a/src/static/__tests__/buildXML.test.js
+++ b/src/static/__tests__/buildXML.test.js
@@ -42,6 +42,15 @@ describe('makeGenerateRouteXML', () => {
       expect(routeXML).toMatchSnapshot()
     })
   })
+
+  it('should use encoding for XML-values', () => {
+    const generateRouteXML = makeGenerateRouteXML({ prefixPath: '/this-&-that/' })
+    const route = {
+      path: '/"官话"-is-chinese-\'ру́сский язы́к\'-is-russian',
+    }
+    const routeXML = generateRouteXML(route)
+    expect(routeXML).toMatchSnapshot()
+  })
 })
 
 describe('generateXML', () => {

--- a/src/static/buildXML.js
+++ b/src/static/buildXML.js
@@ -14,7 +14,17 @@ export const makeGenerateRouteXML = ({ prefixPath }) => route => {
   const { path, lastModified, priority = 0.5 } = route
   return [
     '<url>',
-    `<loc>${getPermaLink({ path, prefixPath })}</loc>`,
+    `<loc>${getPermaLink({ path, prefixPath }).replace(/[<>&'"]/g, c => {
+      switch (c) {
+        case '<': return '&lt;'
+        case '>': return '&gt;'
+        case '&': return '&amp;'
+        case '\'': return '&apos;'
+        case '"': return '&quot;'
+        default:
+          throw new Error('XML encoding failed')
+      }
+    })}</loc>`,
     lastModified ? `<lastmod>${lastModified}</lastmod>` : '',
     `<priority>${priority}</priority>`,
     '</url>',


### PR DESCRIPTION
I had some issues with Google rejecting my sitemap.xml because it contained invalid XML. Some XML characters need te be escaped while generating sitemap.xml (e.g. `&`)

This should fix that.
