### PR TITLE
W3C HTML validator warns about HTML

### DIFF
--- a/examples/cordova/static.config.js
+++ b/examples/cordova/static.config.js
@@ -43,7 +43,7 @@ export default {
           </Head>
           <Body>
             {children}
-            <script type="text/javascript" src="cordova.js" />
+            <script src="cordova.js" />
           </Body>
         </Html>
       )

--- a/src/static/components/BodyWithMeta.js
+++ b/src/static/components/BodyWithMeta.js
@@ -28,13 +28,12 @@ export const makeBodyWithMeta = ({
     <ClientCssHash />
     {!route.redirect && (
       <script
-        type="text/javascript"
         dangerouslySetInnerHTML={generateRouteInformation(embeddedRouteInfo)}
       />
     )}
     {!route.redirect &&
       clientScripts.map(script => (
-        <script key={script} defer type="text/javascript" src={`${config.publicPath}${script}`} />
+        <script key={script} defer src={`${config.publicPath}${script}`} />
       ))}
   </body>
 )

--- a/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
+++ b/src/static/components/__tests__/__snapshots__/BodyWithMeta.test.js.snap
@@ -43,19 +43,16 @@ exports[`BodyWithMeta when route is a static route 1`] = `
     window.__routeInfo = {\\"routeDate\\":\\"here\\"};",
         }
       }
-      type="text/javascript"
     />
     <script
       defer={true}
       key="main.js"
       src="public/pathmain.js"
-      type="text/javascript"
     />
     <script
       defer={true}
       key="bootstrap.js"
       src="public/pathbootstrap.js"
-      type="text/javascript"
     />
   </body>
 </Component>


### PR DESCRIPTION
W3C HTML validator warns about superfluous / deprecated use of `type="text/javascript"` in <script>-tags in  HTML 5.

This change removes them.