### PR TITLE
Fix unresolved config with custom path

### DIFF
--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -97,7 +97,7 @@ const buildConfigFromPath = configPath => {
   const filename = nodePath.resolve(configPath)
   delete require.cache[filename]
   try {
-    const config = require(configPath).default
+    const config = require(filename).default
     return buildConfigation(config)
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
Hey, I encountered an error when trying to provide react-static CLI (v.5.9.7) with custom config path. Here is a one line PR to fix this.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Replaced require call to relative path with a require call to properly resolved file path.

## Motivation and Context
Fixes an error (details below) when running any command with custom config file, eg.: `react-static --config ./custom.static.config.js start`.

Tested also with deep paths from package.json, so running `react-static --config ./example-com/static.config.js start` will now also work.

## Encountered error
```
> react-static --config ./static.config.js start

  Error: Cannot find module './static.config.js'
  
  - loader.js:594 Function.Module._resolveFilename
    internal/modules/cjs/loader.js:594:15
  
  - loader.js:520 Function.Module._load
    internal/modules/cjs/loader.js:520:25
  
  - loader.js:650 Module.require
    internal/modules/cjs/loader.js:650:17
  
  - helpers.js:20 require
    internal/modules/cjs/helpers.js:20:18
  
  - getConfig.js:308 buildConfigFromPath
    [my-static-site]/[react-static]/lib/static/getConfig.js:308:18
  
  - getConfig.js:320 fromFile
    [my-static-site]/[react-static]/lib/static/getConfig.js:320:16
  
  - getConfig.js:344 getConfig
    [my-static-site]/[react-static]/lib/static/getConfig.js:344:10
  
  - start.js:60 Object._callee$
    [my-static-site]/[react-static]/lib/commands/start.js:60:46
  
  - runtime.js:62 tryCatch
    [my-static-site]/[regenerator-runtime]/runtime.js:62:40
  
  - runtime.js:296 Generator.invoke [as _invoke]
    [my-static-site]/[regenerator-runtime]/runtime.js:296:22
  

  TypeError: Cannot read property 'DIST' of undefined
  
  - start.js:70 Object._callee$
    [my-static-site]/[react-static]/lib/commands/start.js:70:58
  
  - runtime.js:62 tryCatch
    [my-static-site]/[regenerator-runtime]/runtime.js:62:40
  
  - runtime.js:296 Generator.invoke [as _invoke]
    [my-static-site]/[regenerator-runtime]/runtime.js:296:22
  
  - runtime.js:114 Generator.prototype.(anonymous function) [as next]
    [my-static-site]/[regenerator-runtime]/runtime.js:114:21
  
  - start.js:33 step
    [my-static-site]/[react-static]/lib/commands/start.js:33:191
  
  - start.js:33 
    [my-static-site]/[react-static]/lib/commands/start.js:33:437
  
  - new Promise
  
  - start.js:33 Object.<anonymous>
    [my-static-site]/[react-static]/lib/commands/start.js:33:99
  
  - start.js:116 Object.start [as default]
    [my-static-site]/[react-static]/lib/commands/start.js:116:17
  
  - react-static-start:17 Object.<anonymous>
    [my-static-site]/[react-static]/bin/react-static-start:17:11
  

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! react-static-example-basic@1.0.1 start: `react-static --config ./static.config.js start`
npm ERR! Exit status 1
```
### Environment details
Node: v10.5.0
NPM: 6.1.0
OS: Ubuntu 18.04 LTS

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
