### PR TITLE
Add temp path config and use it for non-dist files in build

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -398,6 +398,7 @@ export default {
   paths: {
     root: process.cwd(), // The root of your project. Don't change this unless you know what you're doing.
     src: 'src', // The source directory. Must include an index.js entry file.
+    temp: 'tmp', // Temp output directory for build files not to be published.
     dist: 'dist', // The production output directory.
     devDist: 'tmp/dev-server', // The development scratch directory.
     public: 'public' // The public directory (files copied to dist during build)

--- a/src/commands/export.js
+++ b/src/commands/export.js
@@ -29,7 +29,7 @@ export default async ({
     config = await getConfig(originalConfig)
     config.originalConfig = originalConfig
     // Restore the process environment variables that were present during the build
-    const bundledEnv = await fs.readJson(`${config.paths.DIST}/bundle-environment.json`)
+    const bundledEnv = await fs.readJson(`${config.paths.TEMP}/bundle-environment.json`)
     Object.keys(bundledEnv).forEach(key => {
       if (typeof process.env[key] === 'undefined') {
         process.env[key] = bundledEnv[key]
@@ -49,7 +49,7 @@ export default async ({
     console.log(config)
   }
 
-  const clientStats = await fs.readJson(`${config.paths.DIST}/client-stats.json`)
+  const clientStats = await fs.readJson(`${config.paths.TEMP}/client-stats.json`)
 
   if (!clientStats) {
     throw new Error('No Client Stats Found')

--- a/src/static/__mocks__/defaultConfigProduction.mock.js
+++ b/src/static/__mocks__/defaultConfigProduction.mock.js
@@ -7,6 +7,7 @@ export default {
   outputFileRate: 100,
   paths: {
     DIST: './root/dist',
+    TEMP: './root/tmp',
     HTML_TEMPLATE: './root/dist/index.html',
     LOCAL_NODE_MODULES: './dirname/../../node_modules',
     NODE_MODULES: './root/node_modules',

--- a/src/static/getConfig.js
+++ b/src/static/getConfig.js
@@ -30,6 +30,7 @@ export const buildConfigation = (config = {}) => {
     root: nodePath.resolve(process.cwd()),
     src: 'src',
     dist: 'dist',
+    temp: 'tmp',
     devDist: 'tmp/dev-server',
     public: 'public',
     plugins: 'plugins', // TODO: document
@@ -53,6 +54,7 @@ export const buildConfigation = (config = {}) => {
     SRC: resolvePath(config.paths.src),
     PAGES: resolvePath(config.paths.pages),
     PLUGINS: resolvePath(config.paths.plugins),
+    TEMP: resolvePath(config.paths.temp),
     DIST: distPath,
     PUBLIC: resolvePath(config.paths.public),
     NODE_MODULES: resolvePath(config.paths.nodeModules),

--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -314,12 +314,12 @@ export async function buildProductionBundles ({ config }) {
       const prodStatsJson = prodStats.toJson()
 
       fs.outputFileSync(
-        path.join(config.paths.DIST, 'client-stats.json'),
+        path.join(config.paths.TEMP, 'client-stats.json'),
         JSON.stringify(prodStatsJson, null, 2)
       )
 
       fs.outputFileSync(
-        path.join(config.paths.DIST, 'bundle-environment.json'),
+        path.join(config.paths.TEMP, 'bundle-environment.json'),
         JSON.stringify(process.env, null, 2)
       )
 


### PR DESCRIPTION
Add config temp path option, create client-stats.json and bundle-environment.json in temp path instead of dist.

https://github.com/nozzle/react-static/issues/664

## Description

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
