### PR TITLE
Ignore unknown dependency react-static-routes in typescript example

### DIFF
--- a/examples/typescript/src/App.tsx
+++ b/examples/typescript/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Router, Link } from 'react-static'
 
-//
+// tslint:disable-next-line:no-implicit-dependencies
 import Routes from 'react-static-routes'
 
 import './app.css'


### PR DESCRIPTION
## Description

Since `react-static-routes` is auto generated, it should be ignored by tslint when importingl.

## Changes/Tasks

- [x] Added tslint comment flag

## Motivation and Context

Since tslint is often used alongside typescript this PR aims to ease adoption by newcomers to not run into linting errors and by accident installing the `react-static-routes` package.
