### PR TITLE
Set babel runtime module name to @babel/runtime

### DIFF
--- a/babel-preset.js
+++ b/babel-preset.js
@@ -28,7 +28,7 @@ module.exports = () => {
           helpers: false,
           polyfill: false,
           regenerator: true,
-          moduleName: 'babel-runtime',
+          moduleName: '@babel/runtime',
         },
       ],
       r('@babel/plugin-syntax-dynamic-import'),


### PR DESCRIPTION
## Description

Set babel runtime module name to `@babel/runtime` using the new `@babel` namespace. See https://babeljs.io/docs/en/next/babel-plugin-transform-runtime.html#modulename

## Changes/Tasks

- [x] Changed babel-preset

## Motivation and Context

Fixes #670.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
