### PR TITLE
Extend extensions in typescript config example so that pages are discovered

### DIFF
--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -6,6 +6,7 @@ const typescriptWebpackPaths = require('./webpack.config.js')
 
 export default {
   entry: path.join(__dirname, 'src', 'index.tsx'),
+  extensions: ['.js', '.jsx', '.ts', '.tsx'],
   getSiteData: () => ({
     title: 'React Static',
   }),


### PR DESCRIPTION
## Description

`config.extensions` is set to `['.js', '.jsx']` by default. This needs to be extended with `.ts` and `.tsx` to allow auto-discovery of typescript pages.

## Changes/Tasks

- [x] Changed typescript example config

## Motivation and Context

Currently typescript pages are not being discovered in the example thus leading to errors when using `react-static start`:

```
Error: Could not find a route for the "index" page of your site! This is required. Please create a page or specify a route and template for this page.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
