### PR TITLE
Added typescript plugin to typescript example

### DIFF
--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.18.0",
-    "react-static": "^5"
+    "react-static": "next"
   },
   "devDependencies": {
     "@types/axios": "^0.14.0",
@@ -24,7 +24,7 @@
     "convert-tsconfig-paths-to-webpack-aliases": "^0.9.2",
     "eslint-config-react-tools": "1.1.2",
     "serve": "^6.5.3",
-    "ts-loader": "^3.5.0",
+    "ts-loader": "^4.4.2",
     "typescript": "^2.7.2"
   },
   "prettier": {

--- a/examples/typescript/plugins/react-static-plugin-typescript.js
+++ b/examples/typescript/plugins/react-static-plugin-typescript.js
@@ -1,0 +1,24 @@
+export const webpack = (config, { defaultLoaders }) => {
+  config.resolve.extensions.push('.ts', '.tsx')
+
+  config.module.rules[0].oneOf.unshift({
+    test: /\.(ts|tsx)$/,
+    exclude: defaultLoaders.jsLoader.exclude,
+    use: [
+      {
+        loader: 'babel-loader',
+      },
+      {
+        loader: require.resolve('ts-loader'),
+        options: {
+          compilerOptions: {
+            jsx: 'preserve',
+            noEmit: false,
+          },
+        },
+      },
+    ],
+  })
+
+  return config
+}

--- a/examples/typescript/src/index.tsx
+++ b/examples/typescript/src/index.tsx
@@ -11,7 +11,7 @@ export default App
 // Render your app
 if (typeof document !== 'undefined') {
   const renderMethod = module.hot ? ReactDOM.render : ReactDOM.hydrate || ReactDOM.render
-  const render = Comp => {
+  const render = (Comp: React.ReactType) => {
     renderMethod(
       <AppContainer>
         <Comp />

--- a/examples/typescript/static.config.js
+++ b/examples/typescript/static.config.js
@@ -5,12 +5,16 @@ import path from 'path'
 const typescriptWebpackPaths = require('./webpack.config.js')
 
 export default {
+  plugins: ['react-static-plugin-typescript'],
   entry: path.join(__dirname, 'src', 'index.tsx'),
+  extensions: ['.js', '.jsx', '.ts', '.tsx'],
   getSiteData: () => ({
     title: 'React Static',
   }),
   getRoutes: async () => {
-    const { data: posts } = await axios.get('https://jsonplaceholder.typicode.com/posts')
+    const { data: posts } = await axios.get(
+      'https://jsonplaceholder.typicode.com/posts',
+    )
     return [
       {
         path: '/blog',
@@ -27,39 +31,10 @@ export default {
       },
     ]
   },
-  webpack: (config, { defaultLoaders }) => {
-    // Add .ts and .tsx extension to resolver
-    config.resolve.extensions.push('.ts', '.tsx')
-
+  webpack: config => {
     // Add TypeScript Path Mappings (from tsconfig via webpack.config.js)
     // to react-statics alias resolution
     config.resolve.alias = typescriptWebpackPaths.resolve.alias
-
-    // We replace the existing JS rule with one, that allows us to use
-    // both TypeScript and JavaScript interchangeably
-    config.module.rules = [
-      {
-        oneOf: [
-          {
-            test: /\.(js|jsx|ts|tsx)$/,
-            exclude: defaultLoaders.jsLoader.exclude, // as std jsLoader exclude
-            use: [
-              {
-                loader: 'babel-loader',
-              },
-              {
-                loader: require.resolve('ts-loader'),
-                options: {
-                  transpileOnly: true,
-                },
-              },
-            ],
-          },
-          defaultLoaders.cssLoader,
-          defaultLoaders.fileLoader,
-        ],
-      },
-    ]
     return config
   },
 }


### PR DESCRIPTION
## Description

Basic implementation of a typescript plugin. Since there isn't a repo for it (yet), I added it to the typescript example as done with the sass plugin in https://github.com/nozzle/react-static/commit/8795f42d4af455d0e90242ff8d8acbb7cbdbd1fc.

## Motivation and Context

Partially fixes #666. I would like to move this to its own repo and as mentioned in #666 be able to set `entry` and `extensions`. But maybe this is for another PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
