### PR TITLE
Removed double render from typescript example

### DIFF
--- a/examples/typescript/src/index.tsx
+++ b/examples/typescript/src/index.tsx
@@ -22,8 +22,6 @@ if (typeof document !== 'undefined') {
 
   // Render!
   render(App)
-  // Render!
-  render(App)
   // Hot Module Replacement
   if (module.hot) {
     module.hot.accept('./App', () => render(require('./App').default))


### PR DESCRIPTION
## Description

Removed double render from typescript example, I guess this was a copy & paste mistake.

## Motivation and Context

If only one render is required, we should only do one.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
