### PR TITLE
Added url decode before using window.location.href as path

### DIFF
--- a/src/client/components/Router.js
+++ b/src/client/components/Router.js
@@ -43,9 +43,9 @@ export default class Router extends React.Component {
     let { routeInfo } = context
     let path = cleanPath(context.staticURL)
 
-    if (typeof document !== 'undefined') {
+    if (typeof window !== 'undefined') {
       routeInfo = window.__routeInfo
-      const { href } = window.location
+      const href = decodeURIComponent(window.location.href)
       path = cleanPath(href)
     }
 


### PR DESCRIPTION
## Description

When using `window.location.href` we need to url decode it before it can be used as a path for finding template IDs. Otherwise we end up with url encoded paths that can't be reconciled with the build phase were they are url decoded.

## Motivation and Context

Fixes #652. See `bootstrapRouteInfo` for same logic.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
