### PR TITLE
Configure babel to not transpile ES6 modules to CommonJS

### DIFF
--- a/babel-preset.js
+++ b/babel-preset.js
@@ -10,6 +10,7 @@ module.exports = () => {
       [
         r('@babel/preset-env'),
         {
+          modules: false,
           useBuiltIns: false,
           targets: {
             browsers: PRODUCTION

--- a/babel-preset.js
+++ b/babel-preset.js
@@ -1,6 +1,6 @@
 const r = require.resolve
 
-module.exports = () => {
+module.exports = (api, options = {}) => {
   const { NODE_ENV, BABEL_ENV } = process.env
 
   const PRODUCTION = (BABEL_ENV || NODE_ENV) === 'production'
@@ -10,7 +10,7 @@ module.exports = () => {
       [
         r('@babel/preset-env'),
         {
-          modules: false,
+          modules: options.modules,
           useBuiltIns: false,
           targets: {
             browsers: PRODUCTION

--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -1,3 +1,5 @@
+import babelPreset from '../../../../babel-preset';
+
 export default function({ config, stage }) {
   return {
     test: /\.(js|jsx)$/,
@@ -6,6 +8,7 @@ export default function({ config, stage }) {
       {
         loader: 'babel-loader',
         options: {
+          presets: [[babelPreset, { modules: false }]],
           cacheDirectory: stage !== 'prod',
         },
       },

--- a/src/static/webpack/webpack.config.dev.js
+++ b/src/static/webpack/webpack.config.dev.js
@@ -42,7 +42,6 @@ export default function({ config }) {
         path.resolve(__dirname, '../../../node_modules'),
         DIST,
       ],
-      mainFields: ['browser', 'main'],
       extensions: ['.js', '.json', '.jsx'],
     },
     plugins: [

--- a/src/static/webpack/webpack.config.dev.js
+++ b/src/static/webpack/webpack.config.dev.js
@@ -42,7 +42,7 @@ export default function({ config }) {
         path.resolve(__dirname, '../../../node_modules'),
         DIST,
       ],
-      extensions: ['.js', '.json', '.jsx'],
+      extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],
     },
     plugins: [
       new webpack.EnvironmentPlugin(process.env),

--- a/src/static/webpack/webpack.config.dev.js
+++ b/src/static/webpack/webpack.config.dev.js
@@ -33,6 +33,7 @@ export default function({ config }) {
     },
     module: {
       rules: rules({ config, stage: 'dev' }),
+      strictExportPresence: true,
     },
     resolve: {
       modules: [

--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -80,6 +80,7 @@ function common(config) {
     },
     module: {
       rules: rules({ config, stage: 'prod', isNode: false }),
+      strictExportPresence: true,
     },
     resolve: {
       modules: [

--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -89,7 +89,6 @@ function common(config) {
         path.resolve(__dirname, '../../../node_modules'),
         DIST,
       ],
-      mainFields: ['browser', 'main'],
       extensions: ['.js', '.json', '.jsx'],
     },
     externals: [],

--- a/src/static/webpack/webpack.config.prod.js
+++ b/src/static/webpack/webpack.config.prod.js
@@ -89,7 +89,7 @@ function common(config) {
         path.resolve(__dirname, '../../../node_modules'),
         DIST,
       ],
-      extensions: ['.js', '.json', '.jsx'],
+      extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx']
     },
     externals: [],
     target: undefined,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes https://github.com/nozzle/react-static/issues/683
## Description
<!--- Describe your changes in detail -->
This changes the default configuration for babel passed from babel-loader such that the `modules` [option](https://babeljs.io/docs/en/next/babel-preset-env.html#modules) is set to `false`, as well as some other changes to webpack configuration to ensure that ES modules are used instead of CommonJS modules wherever possible.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
 - [x] Added a `modules` option to the built in babel preset. This is necessary because it must be `undefined` when running the node scripts, since node does not support ES modules.
 - [x] Change `jsLoader` such that the babel preset is applied with the `modules` option set to `false`
 - [x] Change `module.strictExportPresence` to `true` in webpack configs. This causes the import of an identifier that is not exported to be an error rather than a warning.
 - [x] Remove the custom setting for `resolve.mainFields` in the webpack configs. This has the effect of changing the custom value `['browser', 'main']` to the current webpack default of `['browser', 'module', 'main']`. This means that ES imports are also used for  packages which include the standard [module](https://github.com/rollup/rollup/wiki/pkg.module) field in `package.json`.
 - [x] Change `resolve.extensions` in webpack config from `['.js', '.json', '.jsx']` to `['.wasm', '.mjs', '.js', '.json', '.jsx']`. This reflects the current webpack default with an added `.jsx` option. It has the effect of prioritising `.mjs` files, which generally have ES exports instead of CommonJS.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/nozzle/react-static/issues/683

 * When the user imports an identifier from an ES6 module that is not exported, webpack throws an error. Previously, there was no error, and instead at runtime the imported variable would be `undefined`. This includes both user code (provided they use ES6 imports/exports), and packages (provided the package provides ES modules in the `module` field of `package.json`). This means the developer gets promptly warned about import errors during compilation instead of experiencing confusing errors in testing or production.
 * Webpack tree shaking works, since webpack is aware of the modules. This can lead to smaller bundle size.

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
