### PR TITLE
[Bugfix] Remove path="*" since its broken with latest dependencies

### DIFF
--- a/src/static/generateRoutes.js
+++ b/src/static/generateRoutes.js
@@ -155,7 +155,7 @@ export default class Routes extends Component {
 
     // This is the default auto-routing renderer
     return (
-      <Route path='*' render={props => {
+      <Route render={props => {
         let Comp = getFullComponentForPath(props.location.pathname)
         // If Comp is used as a component here, it triggers React to re-mount the entire
         // component tree underneath during reconciliation, losing all internal state.


### PR DESCRIPTION
react-router uses path-to-regexp, which will not recognize `*`

Read
https://github.com/pillarjs/path-to-regexp#compatibility-with-express--4x
=> `No wildcard asterisk (*) - use parameters instead ((.*))`

But leaving the path away in react-router `Route` will effectively match all routes.

Please publish if you accept this change :) I'm living on the edge!