### PR TITLE
Fixes CSS Sorting in Issue 622

### DIFF
--- a/src/static/components/HeadWithMeta.js
+++ b/src/static/components/HeadWithMeta.js
@@ -26,9 +26,6 @@ export const makeHeadWithMeta = ({
   const useHelmetTitle =
     head.title && head.title[0] && head.title[0].props.children !== ''
   let childrenArray = React.Children.toArray(children)
-  console.error(`children beforehand:`)
-  console.error(children)
-  console.error(typeof(children))
   if (useHelmetTitle) {
     head.title[0] = React.cloneElement(head.title[0], { key: 'title' })
     childrenArray = children.filter(child => {
@@ -40,8 +37,6 @@ export const makeHeadWithMeta = ({
       return true
     })
   }
-  console.error(`children array beforehand:`)
-  console.error(childrenArray)
   const childrenCSS = childrenArray.filter(child => {
     if (
       child.type === 'link' &&
@@ -69,9 +64,6 @@ export const makeHeadWithMeta = ({
     }
     return true
   })
-  console.error(childrenJS)
-  console.error(childrenCSS)
-  console.error(childrenArray)
 
   const pluginHeads = (config.plugins || [])
     .map(plugin => plugin.Head)

--- a/src/static/components/HeadWithMeta.js
+++ b/src/static/components/HeadWithMeta.js
@@ -59,6 +59,7 @@ export const makeHeadWithMeta = ({
             )}
           />
         ))}
+      {childrenArray}
       {renderLinkCSS &&
         clientStyleSheets.reduce((memo, styleSheet) => {
           const href = makePathAbsolute(
@@ -86,7 +87,6 @@ export const makeHeadWithMeta = ({
       {config.inlineCss && <InlineStyle clientCss={clientCss} />}
       {head.style}
       {pluginHeads}
-      {childrenArray}
     </head>
   )
 }

--- a/src/static/components/HeadWithMeta.js
+++ b/src/static/components/HeadWithMeta.js
@@ -28,7 +28,7 @@ export const makeHeadWithMeta = ({
   let childrenArray = React.Children.toArray(children)
   if (useHelmetTitle) {
     head.title[0] = React.cloneElement(head.title[0], { key: 'title' })
-    childrenArray = children.filter(child => {
+    childrenArray = childrenArray.filter(child => {
       if (child.type === 'title') {
         // Filter out the title of the Document in static.config.js
         // if there is a helmet title on this route
@@ -75,6 +75,7 @@ export const makeHeadWithMeta = ({
       {head.base}
       {useHelmetTitle && head.title}
       {head.meta}
+      {childrenJS}
       {!route.redirect &&
         clientScripts.map(script => (
           <link
@@ -86,6 +87,7 @@ export const makeHeadWithMeta = ({
             )}
           />
         ))}
+      {childrenCSS}
       {renderLinkCSS &&
         clientStyleSheets.reduce((memo, styleSheet) => {
           const href = makePathAbsolute(
@@ -114,8 +116,6 @@ export const makeHeadWithMeta = ({
       {head.style}
       {pluginHeads}
       {childrenArray}
-      {childrenJS}
-      {childrenCSS}
     </head>
   )
 }

--- a/src/static/components/HeadWithMeta.js
+++ b/src/static/components/HeadWithMeta.js
@@ -25,10 +25,13 @@ export const makeHeadWithMeta = ({
   const renderLinkCSS = !route.redirect && !config.inlineCss
   const useHelmetTitle =
     head.title && head.title[0] && head.title[0].props.children !== ''
-  let childrenArray = children
+  let childrenArray = React.Children.toArray(children)
+  console.error(`children beforehand:`)
+  console.error(children)
+  console.error(typeof(children))
   if (useHelmetTitle) {
     head.title[0] = React.cloneElement(head.title[0], { key: 'title' })
-    childrenArray = React.Children.toArray(children).filter(child => {
+    childrenArray = children.filter(child => {
       if (child.type === 'title') {
         // Filter out the title of the Document in static.config.js
         // if there is a helmet title on this route
@@ -37,6 +40,38 @@ export const makeHeadWithMeta = ({
       return true
     })
   }
+  console.error(`children array beforehand:`)
+  console.error(childrenArray)
+  const childrenCSS = childrenArray.filter(child => {
+    if (
+      child.type === 'link' &&
+      child.props &&
+      child.props.rel === 'stylesheet'
+    ) {
+      return true
+    } else if (child.type === 'style') {
+      return true
+    }
+    return false
+  })
+  const childrenJS = childrenArray.filter(child => child.type === 'script')
+  childrenArray = childrenArray.filter(child => {
+    if (
+      child.type === 'link' &&
+      child.props &&
+      child.props.rel === 'stylesheet'
+    ) {
+      return false
+    } else if (child.type === 'style') {
+      return false
+    } else if (child.type === 'script') {
+      return false
+    }
+    return true
+  })
+  console.error(childrenJS)
+  console.error(childrenCSS)
+  console.error(childrenArray)
 
   const pluginHeads = (config.plugins || [])
     .map(plugin => plugin.Head)
@@ -59,7 +94,6 @@ export const makeHeadWithMeta = ({
             )}
           />
         ))}
-      {childrenArray}
       {renderLinkCSS &&
         clientStyleSheets.reduce((memo, styleSheet) => {
           const href = makePathAbsolute(
@@ -87,6 +121,9 @@ export const makeHeadWithMeta = ({
       {config.inlineCss && <InlineStyle clientCss={clientCss} />}
       {head.style}
       {pluginHeads}
+      {childrenArray}
+      {childrenJS}
+      {childrenCSS}
     </head>
   )
 }

--- a/src/static/components/__tests__/__snapshots__/HeadWithMeta.test.js.snap
+++ b/src/static/components/__tests__/__snapshots__/HeadWithMeta.test.js.snap
@@ -97,11 +97,14 @@ exports[`HeadWithMeta when route has no helmet title 1`] = `
       key="clientStyleSheet_bootstrap.css"
       rel="stylesheet"
     />
-    <title>
+    <title
+      key=".0"
+    >
       Document Title
     </title>
     <meta
       content="Helmet application"
+      key=".1"
       name="description"
     />
   </head>


### PR DESCRIPTION
This ensures that the CSS included in the static.config Document head element comes before the component-created CSS.

Fixes [#622](https://github.com/nozzle/react-static/issues/622)

## Description
If users have materialize or other CSS <link> they've declared in the static.config Document() <head> element, those <link>'s will now appear above the component-level CSS that is created by react-static. This fixes the issue in 622 where component-level CSS is being overridden by CSS defined in static.config Document() <head> element. This bug only occurred during react-static build command, not react-static start.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code
- [x] Ensured ordering of static.config Document() <head> CSS <link>'s is now before component-level CSS created by react-static.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[See Issue #622](https://github.com/nozzle/react-static/issues/622)
This change is required to ensure CSS libraries like materialize that are included in static.config Document <head> do not override CSS specified in app and component files.

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] My changes have tests around them
