### PR TITLE
fix webpack build when there is a error loading the page

### DIFF
--- a/src/static/generateRoutes.js
+++ b/src/static/generateRoutes.js
@@ -20,7 +20,7 @@ const universalOptions = {
   loading: () => null,
   error: props => {
     console.error(props.error);
-    return <div>An error occurred loading this page's template. More information is available in the console.</div>;
+    return "An error occurred loading this page's template. More information is available in the console.";
   },
 }
 


### PR DESCRIPTION
## Description
when a page fails to load the universal module trys to show an error, this fails if its a JSX string, as it doesnt give any additional value here, we simple return an error string now.

## Changes/Tasks
- [x] Changed code `generateRoutes.js`

## Motivation and Context
see the description

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
