### PR TITLE
`yarn start` in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you have an idea for a new feature or optimization, discuss it in an issue or
 **In `react-static`:**
 
 1.  Install dependencies by running `yarn`
-2.  Run the development watcher with `yarn watch`. This will watch all files for changes and build automatically to `lib`
+2.  Run the development watcher with `yarn start`. This will watch all files for changes and build automatically to `lib`
 3.  Link react-static globally using `yarn link`. This will make it available on your machine to other projects.
 4.  Make your changes
 


### PR DESCRIPTION
## Description
Replace `yarn watch` with `yarn start` according to change in package.json

## Motivation and Context
`yarn watch` in no longer available in package.json scripts
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
