### PR TITLE
Use react-static package version in create command

### DIFF
--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -9,6 +9,7 @@ import matchSorter from 'match-sorter'
 import downloadGitRepo from 'download-git-repo'
 import { promisify } from 'util'
 import { ChalkColor, time, timeEnd } from '../utils'
+import {version} from '../../package.json';
 
 inquirer.registerPrompt('autocomplete', autoCompletePrompt)
 
@@ -116,8 +117,8 @@ export default (async function create({ name, template, isCLI } = {}) {
     execSync(
       `cd ${name} && ${isYarn ? 'yarn' : 'npm install'} && ${
         isYarn
-          ? 'yarn add react-static@latest'
-          : 'npm install react-static@latest --save'
+          ? `yarn add react-static@${version}`
+          : `npm install react-static@${version} --save`
       }`
     )
     console.log('')


### PR DESCRIPTION
Instead of @latest version, check version in react-static's package.json and use it in yarn/npm commands to add `react-static` dependency.

Fixes #728 

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code

## Motivation and Context
See #728 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
