### PR TITLE
Make message port configurable

### DIFF
--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -94,7 +94,9 @@ export async function startDevServer({ config }) {
     (config.devServer && config.devServer.port) || process.env.PORT || 3000
   const port = await findAvailablePort(Number(intendedPort))
   // Find an available port for messages, as long as it's not the devServer port
-  const messagePort = await findAvailablePort(4000, [port])
+  const intendedMessagePort =
+    (config.devServer && config.devServer.messagePort) || process.env.MESSAGE_PORT || 4000
+  const messagePort = await findAvailablePort(Number(intendedMessagePort), [port])
   if (intendedPort !== port) {
     time(
       chalk.red(


### PR DESCRIPTION
The message port is hard-coded to 4000, this makes it configurable

reopened onto v6 branch as per PR feedback here: https://github.com/nozzle/react-static/pull/724