### PR TITLE
bump netlifycms version to 2.1

### DIFF
--- a/examples/netlifycms/public/admin/index.html
+++ b/examples/netlifycms/public/admin/index.html
@@ -13,7 +13,7 @@
 </head>
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
-  <script src="https://unpkg.com/netlify-cms@^1.0.0/dist/cms.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.1.0/dist/netlify-cms.js"></script>
   <script>
     if (window.netlifyIdentity) {
       window.netlifyIdentity.on("init", user => {


### PR DESCRIPTION
Hi Tanner! just tried the netlifycms template out and it failed when i was authenticated. did some digging and found you were still using 1.0 and the problem went away when i bumped the version to 2.1 (latest). so here's a one line PR.

## Changes/Tasks
- [x] bumped one line in the html

## Motivation and Context
netlifycms template doesnt work anymore without this upgrade


## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
