### PR TITLE
[v6] Don't recompile DIST dir when exporting HTML 

### DIFF
--- a/examples/contentful/src/components/Post.js
+++ b/examples/contentful/src/components/Post.js
@@ -4,8 +4,9 @@ import Moment from 'react-moment'
 import Markdown from 'react-markdown'
 //
 
-const renderHeroImage = (post) => {
-  if (post.heroImage) return <img className="image" src={post.heroImage.fields.file.url} alt="" />
+const renderHeroImage = post => {
+  if (post.heroImage)
+    return <img className="image" src={post.heroImage.fields.file.url} alt="" />
 }
 
 export default withRouteData(({ post }) => (

--- a/examples/contentful/src/contenful/config.js
+++ b/examples/contentful/src/contenful/config.js
@@ -1,6 +1,7 @@
-export const SPACE_ID = "unv3ylsm1w1i"
+export const SPACE_ID = 'unv3ylsm1w1i'
 
 // Content Delivery API access token
-export const CDAPI_ACCESS_TOKEN = "6f761c8e158d291cef131dcef91a7ebce86c59650703c180cdc1cc976be0d098" 
+export const CDAPI_ACCESS_TOKEN =
+  '6f761c8e158d291cef131dcef91a7ebce86c59650703c180cdc1cc976be0d098'
 
-export const POST_CONTENT_TYPE_ID = "blogPost"
+export const POST_CONTENT_TYPE_ID = 'blogPost'

--- a/examples/contentful/src/contenful/fetchPosts.js
+++ b/examples/contentful/src/contenful/fetchPosts.js
@@ -8,12 +8,12 @@ const Client = Contentful.createClient({
   accessToken: Config.CDAPI_ACCESS_TOKEN,
 })
 
-export default (async function getPosts () {
+export default (async function getPosts() {
   const entries = await Client.getEntries({
-      content_type: Config.POST_CONTENT_TYPE_ID,
+    content_type: Config.POST_CONTENT_TYPE_ID,
   })
 
   const posts = _.map(entries.items, item => item.fields)
-  
+
   return posts
 })

--- a/examples/contentful/src/pages/about.js
+++ b/examples/contentful/src/pages/about.js
@@ -1,10 +1,12 @@
-
 import React from 'react'
 //
 
 export default () => (
   <div>
     <h1>This is what we're all about.</h1>
-    <p>React, static sites, performance, speed. It's the stuff that makes us tick.</p>
+    <p>
+      React, static sites, performance, speed. It's the stuff that makes us
+      tick.
+    </p>
   </div>
 )

--- a/src/static/exporter.js
+++ b/src/static/exporter.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/first, import/no-dynamic-require */
 
-require('../utils/binHelper')
+const { setIgnorePath } = require('../utils/binHelper')
 
 import glob from 'glob'
 import path from 'path'
@@ -13,6 +13,9 @@ import { progress } from '../utils'
 export default async ({ config, routes, siteData, clientStats }) => {
   const htmlProgress = progress(routes.length)
   // Use the node version of the app created with webpack
+
+  setIgnorePath(config.paths.DIST)
+
   const Comp = require(glob.sync(
     path.resolve(config.paths.ASSETS, 'static.*.js')
   )[0]).default

--- a/src/static/threadedExporter.js
+++ b/src/static/threadedExporter.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/first, import/no-dynamic-require */
 
-require('../utils/binHelper')
+const { setIgnorePath } = require('../utils/binHelper')
 
 import glob from 'glob'
 import path from 'path'
@@ -15,6 +15,9 @@ process.on('message', async payload => {
     const { config: oldConfig, routes } = payload
     // Get config again
     const config = await getConfig(oldConfig.originalConfig)
+
+    setIgnorePath(config.paths.DIST)
+
     // Use the node version of the app created with webpack
     const Comp = require(glob.sync(
       path.resolve(config.paths.ASSETS, 'static.*.js')

--- a/src/utils/binHelper.js
+++ b/src/utils/binHelper.js
@@ -1,4 +1,16 @@
-require('@babel/register')
+let ignorePath
+
+require('@babel/register')({
+  ignore: [
+    function(filename) {
+      // true if should ignore
+      return /\/node_modules\//.test(filename) ||
+        (ignorePath && ignorePath.test(filename))
+        ? true
+        : false
+    },
+  ],
+})
 
 const updateNotifier = require('update-notifier')
 const PrettyError = require('pretty-error')
@@ -45,3 +57,9 @@ console.error = (err, ...rest) =>
 process.on('unhandledRejection', r => {
   console.error(r)
 })
+
+module.exports = {
+  setIgnorePath(path) {
+    ignorePath = path ? new RegExp(path) : undefined
+  },
+}


### PR DESCRIPTION
## Description

> `@babel/register` uses Node's require() hook system to compile files on the fly when they are loaded. 

This means that https://github.com/nozzle/react-static/blob/v6/src/static/exporter.js#L16 and https://github.com/nozzle/react-static/blob/v6/src/static/threadedExporter.js#L19 will require a file that has already been compiled and minified. This file can be fairly large (1mb+) which means babel might run out of memory when trying to parse and compile again.

## Changes/Tasks

- Added a way to set an ignore path during runtime

## Motivation and Context

Fixes https://github.com/nozzle/react-static/issues/757

## Screenshots (if appropriate):

Fixes this error:

![image](https://user-images.githubusercontent.com/7423098/45792923-75d5fb80-bc55-11e8-8570-7fe1f8606a61.png)


## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
