### PR TITLE
Add anagrams.io to sites built

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ React-Static is a fast, lightweight, and powerful framework for building static-
 * [Luke Haas - Personal Website](https://lukehaas.me)
 * [KleineKoning.nl - Webshop](https://kleinekoning.nl)
 * [Savieo - Save Web Videos](https://savieo.com)
+* [Anagrams.io - Anagram generator](https://anagrams.io)
 
 ## Quick Start
 


### PR DESCRIPTION
I added a website that uses react-static under the hood to the "Sites Built"-section: [anagrams.io](https://anagrams.io).

## Description
Anagrams.io tries to be the best anagram generator ever built, react-static helped me to make it even faster and SEO friendly. 

## Changes/Tasks
- [x] Adds anagrams.io to "Sites Built"

## Motivation and Context
It adds a website that's different than all the other "Sites Built" websites and shows that SVG generation and animations are no problem at all.

## Screenshots (if appropriate):
<img width="852" alt="screen shot 2018-09-20 at 09 50 44" src="https://user-images.githubusercontent.com/2116347/45803770-b156e100-bcba-11e8-862a-ca35d48e9a10.png">


## Types of changes
- [x] Extend documentation

## Checklist:
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
