### PR TITLE
fix double compiling of node_modules

### DIFF
--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -37,6 +37,7 @@ export default function({ config, stage }) {
         loader: 'babel-loader',
         options: {
           ...babelFile,
+          exclude: new RegExp(`(node_modules|${config.paths.EXCLUDE_MODULES})`),
           root: config.paths.ROOT,
           presets: [[babelPreset, { modules: false }]],
           cacheDirectory: isRelativePath ? stage !== 'prod' : config.paths.TEMP,


### PR DESCRIPTION
## Description

https://github.com/nozzle/react-static/commit/ad87562fd912acf2479c2843937ceee8cc7e3673 introduced some double compiling.
like here: https://github.com/glimmerjs/glimmer-application-pipeline/issues/87

so excluding `node_modules` we must!

## Changes/Tasks
- [x ] Changed code

## Motivation and Context

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
