### PR TITLE
Correct spelling of babel.config.js

### DIFF
--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -3,7 +3,7 @@ import babelPreset from '../../../../babel-preset';
 
 // we check which babel config file exists in the project root
 const readBabelConfig = (root) => {
-  const babelFiles = [`${root}/.babelrc`, `${root}/.babelrc.js`,`${root}/.babel.config.js`];
+  const babelFiles = [`${root}/.babelrc`, `${root}/.babelrc.js`,`${root}/babel.config.js`];
 
   let extendsFile = {};
 


### PR DESCRIPTION
## Description

`babel.config.js` doesn't have a period in front.

https://babeljs.io/docs/en/config-files#project-wide-configuration

## Changes/Tasks
- [x] Changed code

## Motivation and Context

My project uses a `babel.config.js` file.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
