### PR TITLE
Make sure to run the config.webpack hook

### DIFF
--- a/src/static/webpack/index.js
+++ b/src/static/webpack/index.js
@@ -49,7 +49,7 @@ export function webpackConfig({ config, stage }) {
 
   const defaultLoaders = getStagedRules({ config, stage })
 
-  const transformers = getPluginHooks(config.plugins, 'webpack').reduce(
+  const transformers = getPluginHooks(config.plugins, 'webpack').concat(config.webpack || []).reduce(
     (all, curr) => {
       if (Array.isArray(curr)) {
         return [...all, ...curr]
@@ -57,17 +57,21 @@ export function webpackConfig({ config, stage }) {
       return [...all, curr]
     },
     []
-  )
+  );
 
   transformers.forEach(transformer => {
-    const modifiedConfig = transformer(webpackConfig, {
-      stage,
-      defaultLoaders,
-    })
-    if (modifiedConfig) {
-      webpackConfig = modifiedConfig
+    if (typeof transformer === 'function') {
+      const modifiedConfig = transformer(webpackConfig, {
+        stage,
+        defaultLoaders,
+      })
+
+      if (modifiedConfig) {
+        webpackConfig = modifiedConfig
+      }
     }
   })
+
   return webpackConfig
 }
 


### PR DESCRIPTION
## Description

[This commit](https://github.com/nozzle/react-static/commit/58fee0247a87d44e75a5f3ccf8ca5a1337e8fa69#diff-aca7fc77f9db0ace2a7962f2e30c4085L57) changed the `getPluginHooks` function which now only includes `config.plugins` array and no longer includes `config.webpack`.

## Changes/Tasks
- [x] Changed code

## Motivation and Context

https://github.com/nozzle/react-static/blob/v6/docs/plugins.md#webpack-functionfunction

We should still be able to configure webpack without having to create a plugin. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
