### PR TITLE
compile node_modules with bare minimum too

### DIFF
--- a/babel-preset-external.js
+++ b/babel-preset-external.js
@@ -1,0 +1,74 @@
+const r = require.resolve
+
+module.exports = (api, options = {}) => {
+  const { NODE_ENV, BABEL_ENV } = process.env
+
+  const PRODUCTION = (BABEL_ENV || NODE_ENV) === 'production'
+  const DEVELOPMENT = (BABEL_ENV || NODE_ENV) === 'development'
+  const TEST = (BABEL_ENV || NODE_ENV) === 'test'
+
+  return {
+    // Babel assumes ES Modules, which isn't safe until CommonJS
+    // dies. This changes the behavior to assume CommonJS unless
+    // an `import` or `export` is present in the file.
+    // https://github.com/webpack/webpack/issues/4039#issuecomment-419284940
+    sourceType: 'unambiguous',
+    presets: [
+      TEST && [
+        // ES features necessary for user's Node version
+        r('@babel/preset-env'),
+        {
+          targets: {
+            node: 'current',
+          },
+          // Do not transform modules to CJS
+          modules: false,
+        },
+      ],
+      (PRODUCTION || DEVELOPMENT) && [
+        // Latest stable ECMAScript features
+        r('@babel/preset-env'),
+        {
+          // We want Create React App to be IE 9 compatible until React itself
+          // no longer works with IE 9
+          targets: {
+            ie: 9,
+          },
+          // Users cannot override this behavior because this Babel
+          // configuration is highly tuned for ES5 support
+          ignoreBrowserslistConfig: true,
+          // If users import all core-js they're probably not concerned with
+          // bundle size. We shouldn't rely on magic to try and shrink it.
+          useBuiltIns: false,
+          // Do not transform modules to CJS
+          modules: false,
+        },
+      ],
+    ].filter(Boolean),
+    plugins: [
+      // Polyfills the runtime needed for async/await, generators, and friends
+      // https://babeljs.io/docs/en/babel-plugin-transform-runtime
+      [
+        r('@babel/plugin-transform-runtime'),
+        {
+          corejs: false,
+          helpers: !!options.helpers,
+          regenerator: true,
+          // https://babeljs.io/docs/en/babel-plugin-transform-runtime#useesmodules
+          // We should turn this on once the lowest version of Node LTS
+          // supports ES Modules.
+          useESModules: DEVELOPMENT || PRODUCTION,
+          // Undocumented option that lets us encapsulate our runtime, ensuring
+          // the correct version is used
+          // https://github.com/babel/babel/blob/090c364a90fe73d36a30707fc612ce037bdbbb24/packages/babel-plugin-transform-runtime/src/index.js#L35-L42
+          // absoluteRuntime: absoluteRuntimePath,
+        },
+      ],
+      // Adds syntax support for import()
+      r('@babel/plugin-syntax-dynamic-import'),
+      TEST &&
+        // Transform dynamic import to require
+        r('babel-plugin-transform-dynamic-import'),
+    ].filter(Boolean),
+  }
+}

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "socket.io-client": "^2.1.1",
     "style-loader": "0.23.0",
     "swimmer": "^1.4.0",
+    "thread-loader": "^1.2.0",
     "uglifyjs-webpack-plugin": "^1.3.0",
     "upath": "^1.1.0",
     "update-notifier": "^2.5.0",

--- a/src/static/webpack/rules/index.js
+++ b/src/static/webpack/rules/index.js
@@ -1,15 +1,17 @@
 import jsLoader from './jsLoader'
 import cssLoader from './cssLoader'
 import fileLoader from './fileLoader'
+import jsLoaderExternal from './jsLoaderExternal';
 
 export const getStagedRules = args => ({
   jsLoader: jsLoader(args),
+  jsLoaderExt: jsLoaderExternal(args),
   cssLoader: cssLoader(args),
   fileLoader: fileLoader(args),
 })
 
 export default args => [
   {
-    oneOf: [jsLoader(args), cssLoader(args), fileLoader(args)],
+    oneOf: [jsLoader(args), jsLoaderExternal(args), cssLoader(args), fileLoader(args)],
   },
 ]

--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -32,7 +32,9 @@ export default function({ config, stage }) {
 
   return {
     test: /\.(js|jsx|mjs)$/,
+    include: [config.paths.SRC, `${config.paths.DIST}/react-static-routes.js`],
     use: [
+      // 'thread-loader',
       {
         loader: 'babel-loader',
         options: {

--- a/src/static/webpack/rules/jsLoaderExternal.js
+++ b/src/static/webpack/rules/jsLoaderExternal.js
@@ -1,0 +1,28 @@
+import babelPreset from '../../../../babel-preset-external';
+
+export default function() {
+
+  return {
+    test: /\.(js|jsx|mjs)$/,
+    exclude: /@babel(?:\/|\\{1,2})runtime/,
+    use: [
+      // 'thread-loader',
+      {
+        loader: 'babel-loader',
+        options: {
+          babelrc: false,
+          configFile: false,
+          compact: false,
+          presets: [
+            [
+              babelPreset,
+              { helpers: true },
+            ],
+          ],
+          cacheDirectory: true,
+          sourceMaps: false,
+        },
+      },
+    ],
+  }
+}

--- a/src/utils/chunkBuilder.js
+++ b/src/utils/chunkBuilder.js
@@ -28,8 +28,8 @@ export const absoluteToRelativeChunkName = (ROOT, chunkName) => {
     ''
   )
 
-  if (relativeChunkName.startsWith("-")) {
-    relativeChunkName = relativeChunkName.substr(1);
+  if (relativeChunkName.startsWith('-')) {
+    relativeChunkName = relativeChunkName.substr(1)
   }
 
   // cut of the extension if any

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,7 @@ async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.4, async@^2.5.0:
+async@^2.1.4, async@^2.3.0, async@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:
@@ -8435,6 +8435,14 @@ test-exclude@^4.2.1:
 text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+thread-loader@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/thread-loader/-/thread-loader-1.2.0.tgz#35dedb23cf294afbbce6c45c1339b950ed17e7a4"
+  dependencies:
+    async "^2.3.0"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
as a general exclude on node_modules doesnt seem to be a good idea, we compile them too (but with a bare minimum of features). the idea is inspired by CRA https://github.com/facebook/create-react-app/blob/next/packages/react-scripts/config/webpack.config.prod.js#L313-L353

## Description

separate babel loaders for SRC and NODE_MODULES

## Changes/Tasks
- [x] Changed code

## Motivation and Context
to be able to use external ESM 

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
