### PR TITLE
Add StaticGen.com to the list of sites built with React-Static

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ React-Static is a fast, lightweight, and powerful framework for building static-
 * [Nozzle.io](https://nozzle.io) ([source](https://github.com/nozzle/nozzle.io))
 * [Timber.io](https://timber.io)
 * [HeadlessCMS.org](https://headlesscms.org) ([source](https://github.com/netlify/headlesscms.org))
+* [StaticGen.com](https://www.staticgen.com) ([source](https://github.com/netlify/staticgen))
 * [Manta.life](https://manta.life) ([source](https://github.com/MantaApp/Website))
 * [Manticore Games](http://manticoregames.com)
 * [BlackSandSolutions.co](https://www.blacksandsolutions.co)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I noticed that the **Sites Built with React-Static** section of the README included [HeadlessCMS.org](https://headlesscms.org) but not [StaticGen.com](https://www.staticgen.com), which was [recently "migrate[d] over to React Static using headlesscms repo as a template"](https://github.com/netlify/staticgen/pull/370). That seems like a major endorsement of React-Static as a static site generator (almost on par with the React documentation site using Gatsby) and should not go unnoticed.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Add StaticGen.com to the list of sites built with React-Static

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See Description.
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
