### PR TITLE
make the static files location more flexible

### DIFF
--- a/src/static/webpack/rules/jsLoader.js
+++ b/src/static/webpack/rules/jsLoader.js
@@ -36,8 +36,8 @@ export default function({ config, stage }) {
     test: /\.(js|jsx|mjs)$/,
     include: [
       config.paths.SRC,
-      `${config.paths.DIST}/react-static-routes.js`,
-      `${config.paths.DIST}/react-static-browser-plugins.js`,
+      /react-static-routes\.js/,
+      /react-static-browser-plugins\.js/,
     ],
     use: [
       // 'thread-loader',


### PR DESCRIPTION
somehow the `tmp` paths on OSX behave weird, so we simple change the static files to a regex on the filename
