### PR TITLE
Add missing dependency to material-ui template

### DIFF
--- a/examples/material-ui/package.json
+++ b/examples/material-ui/package.json
@@ -12,6 +12,7 @@
     "@material-ui/core": "^3.0.3",
     "@material-ui/icons": "^3.0.1",
     "axios": "^0.18.0",
+    "react-jss": "^8.6.1",
     "react-router-dom": "^4.3.1",
     "react-static": "^5.9.8"
   },


### PR DESCRIPTION
## Description
Material-UI removed their dependency to `react-jss` in `v3.2.0` so it no longer gets pulled in automatically.

## Changes/Tasks
I added `react-jss` dependency to material-ui's template

## Motivation and Context
This PR solves #818 