### PR TITLE
fix: example documentation watching incorrect dir

### DIFF
--- a/examples/documentation/static.config.js
+++ b/examples/documentation/static.config.js
@@ -5,7 +5,7 @@ import React, { Component } from 'react'
 import { ServerStyleSheet } from 'styled-components'
 import chokidar from 'chokidar'
 
-chokidar.watch('../docs').on('all', () => reloadRoutes())
+chokidar.watch('./docs').on('all', () => reloadRoutes())
 
 //
 


### PR DESCRIPTION
Fix the incorrect watched directory configured in `example/documentation`

## Description
Recently I tried to use the `documentation` template, found that the doc folder being watched do not point correctly at the template's own doc folder. This might be confusing for starters. 

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [ ] Changed code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tested in my local mac that after this fixing, the template project created by `react-static create` with `documentation` type will be correctly watching the project `doc` directory and rebuild nicely  in development.

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] My changes have tests around them
