### PR TITLE
Update material-ui example

### DIFF
--- a/examples/material-ui/package.json
+++ b/examples/material-ui/package.json
@@ -9,9 +9,11 @@
     "serve": "serve dist -p 3000"
   },
   "dependencies": {
-    "@material-ui/core": "^3.0.3",
+    "@material-ui/core": "^3.2.2",
     "@material-ui/icons": "^3.0.1",
     "axios": "^0.18.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
     "react-jss": "^8.6.1",
     "react-router-dom": "^4.3.1",
     "react-static": "^5.9.8"

--- a/examples/material-ui/src/containers/404.js
+++ b/examples/material-ui/src/containers/404.js
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography'
 
 export default () => (
   <div>
-    <Typography type="headline" align="center">
+    <Typography type="h5" align="center">
       404 - Oh no's! We couldn't find that page :(
     </Typography>
   </div>

--- a/examples/material-ui/src/containers/About.js
+++ b/examples/material-ui/src/containers/About.js
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography'
 
 export default () => (
   <div>
-    <Typography type="headline" gutterBottom>
+    <Typography type="h5" gutterBottom>
       This is what we're all about.
     </Typography>
     <Typography type="body1">

--- a/examples/material-ui/src/containers/Blog.js
+++ b/examples/material-ui/src/containers/Blog.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography'
 
 export default withRouteData(({ posts }) => (
   <div>
-    <Typography type="headline" gutterBottom>
+    <Typography type="h5" gutterBottom>
       It's blog time.
     </Typography>
     <Typography type="body1" component="div">

--- a/examples/material-ui/src/containers/Home.js
+++ b/examples/material-ui/src/containers/Home.js
@@ -6,7 +6,7 @@ import logoImg from '../logo.png'
 
 export default withSiteData(() => (
   <div>
-    <Typography type="headline" align="center" gutterBottom>
+    <Typography type="h5" align="center" gutterBottom>
       Welcome to
     </Typography>
     <img src={logoImg} alt="" style={{ display: 'block', margin: '0 auto' }} />

--- a/examples/material-ui/src/containers/Post.js
+++ b/examples/material-ui/src/containers/Post.js
@@ -9,7 +9,7 @@ export default withRouteData(({ post }) => (
     <Typography type="body1" component={Link} to="/blog" gutterBottom>
       {'<'} Back
     </Typography>
-    <Typography type="title" gutterBottom>
+    <Typography type="h6" gutterBottom>
       {post.title}
     </Typography>
     <Typography type="body1">

--- a/examples/material-ui/src/theme.js
+++ b/examples/material-ui/src/theme.js
@@ -9,4 +9,7 @@ export default {
       appBar: '#108db8',
     },
   },
+  typography: {
+    useNextVariants: true,
+  },
 }

--- a/examples/material-ui/static.config.js
+++ b/examples/material-ui/static.config.js
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import React, { Component } from 'react'
-import { SheetsRegistry } from 'react-jss/lib/jss'
-import JssProvider from 'react-jss/lib/JssProvider'
+import { JssProvider, SheetsRegistry } from 'react-jss'
 import { MuiThemeProvider, createMuiTheme, createGenerateClassName } from '@material-ui/core/styles'
 
 // Your Material UI Custom theme


### PR DESCRIPTION
## Description
Updated material-ui example to use latest core version. Closes #806

## Changes/Tasks
- removed deprecated typography usage: https://material-ui.com/style/typography/#strategies
- add react and react-dom to deps
- Removed private imports from jss

## Motivation and Context
Typography is deprecated which can cause some confusion when installing the the example. I know @krvajal claimed it but the issue has been open for 3 weeks, is considered chore and I already used those changes when experimenting with react-static.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
 - Do you have tests for examples?
