### PR TITLE
fix(travis-ci): build react-static before testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - "9"
   - "8"
   - "7"
-script: npm test
+script: npm run build && npm test


### PR DESCRIPTION
test-sample-build assumes that react-static has been built locally

## Description
Travis CI started failing after this commit: https://github.com/nozzle/react-static/commit/fb126d9d9632752cfadc0ba68d64268b165accfe#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L30

## Changes/Tasks
- [x] Update travis-ci config to run `npm build` before `npm test`
