### PR TITLE
fix: Accept config arg in CLI start command

### DIFF
--- a/packages/react-static/src/commands/start.js
+++ b/packages/react-static/src/commands/start.js
@@ -13,7 +13,7 @@ import { createIndexFilePlaceholder } from '../utils'
 let cleaned
 let indexCreated
 
-export default (async function start({ configPath, debug } = {}) {
+export default (async function start({ config: configPath, debug } = {}) {
   // ensure ENV variables are set
   if (typeof process.env.NODE_ENV === 'undefined') {
     process.env.NODE_ENV = 'development'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `--config` CLI argument's currently broken in v6. The [exported `start` command](https://github.com/nozzle/react-static/blob/c270bc879cc49fd42bd448a33bd337116385db3f/packages/react-static/src/commands/start.js#L16) takes in `configPath` as its argument, but the start bin [still passes `config`](https://github.com/nozzle/react-static/blob/c270bc879cc49fd42bd448a33bd337116385db3f/packages/react-static/bin/react-static-start#L17).

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Rename `config` to `configPath` in start

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This issue: https://github.com/nozzle/react-static/issues/848


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
