### PR TITLE
Fix issues with windows paths

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -66,6 +66,7 @@
     "inquirer": "^6.1.0",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "intersection-observer": "^0.5.1",
+    "lodash": "^4.17.11",
     "match-sorter": "^2.2.3",
     "minimist": "^1.2.0",
     "mutation-observer": "^1.0.3",

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -66,7 +66,6 @@
     "inquirer": "^6.1.0",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "intersection-observer": "^0.5.1",
-    "lodash": "^4.17.11",
     "match-sorter": "^2.2.3",
     "minimist": "^1.2.0",
     "mutation-observer": "^1.0.3",

--- a/packages/react-static/src/static/getRoutes/getRoutesFromPages.js
+++ b/packages/react-static/src/static/getRoutes/getRoutesFromPages.js
@@ -20,10 +20,14 @@ export default (async function getRoutesFromPages(
   const handle = pages => {
     // Turn each page into a route
     const routes = pages.map(page => {
+      // Glob path will always have unix style path, convert to windows if necessary
+      page = nodePath.resolve(page)
       // Get the component path relative to ROOT
       const component = nodePath.relative(config.paths.ROOT, page)
       // Make sure the path is relative to the root of the site
       let path = page.replace(`${config.paths.PAGES}`, '').replace(/\..*/, '')
+      // turn windows paths back to unix
+      path = path.split('\\').join('/')
       // Turn `/index` paths into roots`
       path = path.replace(/\/index$/, '/')
       // Return the route
@@ -47,7 +51,7 @@ export default (async function getRoutesFromPages(
           if (!['add', 'unlink'].includes(type)) {
             return
           }
-          const filename = file.split('/').reverse()[0]
+          const filename = path.basename(file)
           if (filename.startsWith('.')) {
             return
           }

--- a/packages/react-static/src/static/getRoutes/getRoutesFromPages.js
+++ b/packages/react-static/src/static/getRoutes/getRoutesFromPages.js
@@ -51,7 +51,7 @@ export default (async function getRoutesFromPages(
           if (!['add', 'unlink'].includes(type)) {
             return
           }
-          const filename = path.basename(file)
+          const filename = nodePath.basename(file)
           if (filename.startsWith('.')) {
             return
           }

--- a/packages/react-static/src/utils/binHelper.js
+++ b/packages/react-static/src/utils/binHelper.js
@@ -1,9 +1,21 @@
+const path = require('path');
+const escapeRegExp = require('lodash/escapeRegExp');
 let ignorePath
 
 // Allow as much stack tracing as possible
 Error.stackTraceLimit = Infinity
 
-require('@babel/register')({})
+require('@babel/register')({
+  ignore: [
+    function babelIgnore(filename) {
+      // true if should ignore
+      return (
+        new RegExp(escapeRegExp(`${path.sep}node_modules${path.sep}`)).test(filename) ||
+        (ignorePath && ignorePath.test(filename))
+      )
+    },
+  ],
+});
 
 const updateNotifier = require('update-notifier')
 const PrettyError = require('pretty-error')
@@ -53,6 +65,6 @@ process.on('unhandledRejection', r => {
 
 module.exports = {
   setIgnorePath(path) {
-    ignorePath = path ? new RegExp(path) : undefined
+    ignorePath = path ? new RegExp(escapeRegExp(path)) : undefined
   },
 }

--- a/packages/react-static/src/utils/binHelper.js
+++ b/packages/react-static/src/utils/binHelper.js
@@ -3,17 +3,7 @@ let ignorePath
 // Allow as much stack tracing as possible
 Error.stackTraceLimit = Infinity
 
-require('@babel/register')({
-  ignore: [
-    function babelIgnore(filename) {
-      // true if should ignore
-      return (
-        /\/node_modules\//.test(filename) ||
-        (ignorePath && ignorePath.test(filename))
-      )
-    },
-  ],
-})
+require('@babel/register')({})
 
 const updateNotifier = require('update-notifier')
 const PrettyError = require('pretty-error')

--- a/packages/react-static/src/utils/binHelper.js
+++ b/packages/react-static/src/utils/binHelper.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const escapeRegExp = require('lodash/escapeRegExp');
+
 let ignorePath
 
 // Allow as much stack tracing as possible

--- a/packages/react-static/src/utils/binHelper.js
+++ b/packages/react-static/src/utils/binHelper.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const escapeRegExp = require('lodash/escapeRegExp');
+const { escapeRegExp } = require('./')
 
 let ignorePath
 


### PR DESCRIPTION
See https://github.com/babel/babel/issues/9032

I'm not sure if the ignore path is necessary. But I know it will cause issues in its current form. I'm not able to start any react-static example without this change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)