### PR TITLE
Fix Windows path handling in generateTemplates.js

### DIFF
--- a/packages/react-static/src/static/generateTemplates.js
+++ b/packages/react-static/src/static/generateTemplates.js
@@ -9,11 +9,13 @@ export default async ({ config }) => {
   const route404 = routes.find(route => route.path === '404')
   const id404 = route404.templateIndex
 
-  const productionImports = `
-import universal, { setHasBabelPlugin } from '${
-    process.env.REACT_STATIC_UNIVERSAL_PATH
-  }'
-  `
+  // convert Windows-style path separators to the Unix style to ensure sure the
+  // string literal is valid and doesn't contain escaped characters
+  const reactStaticUniversalPath = process.env.REACT_STATIC_UNIVERSAL_PATH.split(
+    '\\'
+  ).join('/')
+
+  const productionImports = `import universal, { setHasBabelPlugin } from '${reactStaticUniversalPath}'`
   const developmentImports = ''
 
   const productionTemplates = `


### PR DESCRIPTION
## Description

Tries to fix #877.

The solution is to convert the value of `REACT_STATIC_UNIVERSAL_PATH` from Windows-style path separators to Unix-style using the `.split('\\').join('/')` trick as has been done in some other files.

(I say try, because trying to build the repo results in the following warning, and no build results:)

```
PS C:\koodia\react-static> yarn build
yarn run v1.7.0
$ lerna run 'build' --ignore react-static-example-*
lerna notice cli v3.5.1
lerna info filter [ '!react-static-example-*' ]
lerna success run No packages found with the lifecycle script ''build''
Done in 0.61s.
``` 

(This is with latest versions of Node, Yarn and Lerna)

## Changes/Tasks
- [x] Fix the issue introduced in 7363c0b236d4d04d7b5c8a004f0011f9a0028122

## Motivation and Context
Might fix #877. I've been unable to run this PR, so I don't know if there are some other issues preventing Windows builds from working.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
