### PR TITLE
fix css-loader 2.0 version breaks (removed minimize option)

### DIFF
--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -1,4 +1,5 @@
 import ExtractCssChunks from 'extract-css-chunks-webpack-plugin'
+import semver from 'semver';
 
 export default ({ includePaths = [], ...rest }) => ({
   webpack: (config, { stage }) => {
@@ -15,7 +16,6 @@ export default ({ includePaths = [], ...rest }) => ({
       loader: 'css-loader',
       options: {
         importLoaders: 1,
-        minimize: stage === 'prod',
         sourceMap: false,
       },
     }
@@ -29,6 +29,14 @@ export default ({ includePaths = [], ...rest }) => ({
       loaders = [cssLoader, sassLoader]
     } else {
       // Prod
+
+      // for legacy css-loader version (<2.0) we need to add "minimize" to minify css code
+      // for >2.0 it is handled with https://github.com/NMFR/optimize-css-assets-webpack-plugin
+      const cssLoaderVersion = require('css-loader/package.json').version;
+      if (semver.satisfies(cssLoaderVersion, '<2') === true) {
+        cssLoader.options.minimize = true;
+      }
+
       loaders = [ExtractCssChunks.loader, cssLoader, sassLoader]
     }
 


### PR DESCRIPTION
## Description

fix `css-loader` 2.0 version changes.
The `minimize`option was removed. I add the minimize option (like before) for older versions. at some point we can drop this backport.

## Changes/Tasks

- [x] Changed code

## Motivation and Context

https://github.com/webpack-contrib/css-loader/issues/863

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
