### PR TITLE
less aggressive prefetching (check if link should be prefetched)

### DIFF
--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -1,6 +1,11 @@
 import axios from 'axios'
 //
-import { createPool, getRoutePath, pathJoin } from './utils'
+import {
+  createPool,
+  getRoutePath,
+  pathJoin,
+  isPrefetchableRoute,
+} from './utils'
 import onVisible from './utils/Visibility'
 
 // RouteInfo / RouteData
@@ -112,6 +117,11 @@ export function reloadRouteData() {
 
 export async function getRouteInfo(path, { priority } = {}) {
   path = getRoutePath(path)
+
+  // Check if we should fetch RouteData for this url et all.
+  if (!isPrefetchableRoute(path)) {
+    return
+  }
 
   // Check the cache first
   if (routeInfoByPath[path]) {

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -198,3 +198,39 @@ export function getBasePath() {
     ? ''
     : process.env.REACT_STATIC_BASE_PATH
 }
+
+export function isPrefetchableRoute(path) {
+  // when rendering static pages we dont need this et all
+  if (isSSR()) {
+    return false;
+  }
+
+  // script links
+  if (path.indexOf('javascript:') === 0) {
+    return false;
+  }
+
+  const self = document.location;
+  let link;
+
+  try {
+    link = new URL(path);
+  } catch (e) {
+    // if a path is not parsable by URL its a local relative path
+    return true;
+  }
+
+  // if the hostname/port/proto doesnt match its not a route link
+  if (self.hostname !== link.hostname || 
+    self.port !== link.port || 
+    self.protocol !== link.protocol) {
+    return false;
+  }
+
+  //deny all files with extension other than .html
+  if (link.pathname.includes('.') && !link.pathname.includes('.html')) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Description

we do some checks now if the link should be prefetched et all.

## Changes/Tasks

- [x] Changed code

## Motivation and Context

a lot of avoidable `routeInfo.json` requests are dropped which results in `404` responses (to e.g. external urls or `javascript:` links)

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
