### PR TITLE
Add react-static-plugin-typescript to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Once you've installed and test driven, you may want to:
   - [react-static-plugin-sass](/packages/react-static-plugin-sass) - Adds SSR and general support for SASS
 - React Alternatives
   - [react-static-plugin-preact](/packages/react-static-plugin-preact) - Adds preact support
+- Type checking
+  - [react-static-plugin-typescript](https://www.npmjs.com/package/react-static-plugin-typescript) - Allows you to write your components in TypeScript
 - Don't see a plugin? [Help us build it!](/docs/plugins.md)
 
 ## Templates and Guides


### PR DESCRIPTION
## Description

I created react-static-plugin-typescript; this PR adds it to the list of plugins.

Note: on Twitter I mentioned wanting to give this a more thorough run-through on my own project, but since I'm [stuck on upgrading that](https://spectrum.chat/react-static/general/how-to-use-reach-router-with-react-static-v6~c0b4658e-bd3c-4d15-93da-8391a491b9dc) I figured I'd submit this anyway, since it otherwise appears to work fine.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Updated plugin list in README

## Motivation and Context
It tells people who want to use TypeScript which plugin they can use.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
