### PR TITLE
Add trailing commas to object properties

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -289,9 +289,9 @@ export default {
     temp: 'tmp', // Temp output directory for build files not to be published.
     dist: 'dist', // The production output directory.
     devDist: 'tmp/dev-server', // The development scratch directory.
-    public: 'public' // The public directory (files copied to dist during build)
-    assets: 'dist' // The output directory for bundled JS and CSS
-  }
+    public: 'public', // The public directory (files copied to dist during build)
+    assets: 'dist', // The output directory for bundled JS and CSS
+  },
 }
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There is a comma missing after the `public` property causing the object to be invalid. I added this comma, in addition to other trailing commas to match the coding style of other code examples on this page.


## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Add missing comma for `public` property
- [x] Add trailing commas to match code style

## Motivation and Context
I copy/pasted the offending code example and had a compile error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
