### PR TITLE
Add Root Component typescript types

### DIFF
--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -16,6 +16,16 @@ declare module 'react-static' {
   // Generated Routes
   export class Routes extends React.Component {}
 
+  export type RootProps = {
+    disableScroller?: boolean,
+    autoScrollToTop?: boolean,
+    autoScrollToHash?: boolean,
+    scrollToTopDuration?: number,
+    scrollToHashDuration?: number,
+    scrollToHashOffset?: number,
+  }
+  export class Root extends React.Component<RootProps> {}
+
   export function withRouteData(comp: any): any
   export function withSiteData(comp: any): any
   export const RouteData: React.Component


### PR DESCRIPTION
I'm not sure if there's any other prop in Root.
Also, I'm not sure if type RootProps  should be where it is or if it should be exported at all.