### PR TITLE
let webpack resolve with absolute paths in case of an absolute output…

### DIFF
--- a/packages/react-static/src/static/buildHTML.js
+++ b/packages/react-static/src/static/buildHTML.js
@@ -15,7 +15,7 @@ export default (async function buildHTML({
   time(chalk.green('=> [\u2713] HTML Exported'))
 
   // in case of an absolute path for DIST we must tell node to load the modules from our project root
-  if (config.paths.DIST.indexOf(config.paths.ROOT) !== 0) {
+  if (!config.paths.DIST.startsWith(config.paths.ROOT)) {
     process.env.NODE_PATH = config.paths.NODE_MODULES
     require('module').Module._initPaths()
   }

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -102,7 +102,11 @@ function common(config) {
           NODE_MODULES,
           path.resolve(__dirname, '../../../node_modules'),
           DIST,
-        ].map(d => path.relative(process.cwd(), d)),
+        ].map(d =>
+          DIST.startsWith(ROOT)
+            ? path.relative(process.cwd(), d)
+            : path.resolve(d)
+        ),
         'node_modules',
       ],
       extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],


### PR DESCRIPTION
there was a bug (recently introduced?, it worked with an older react-static beta) when building to an absolute `DIST` path. in case of an absolute `DIST` path we simply tell webpack to resolve all modules with absolute paths.

@tannerlinsley this is relativly urgent :)