### PR TITLE
Make sure plugin options are passed on to plugins

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -130,7 +130,8 @@
     "testRegex": "(/__tests__/.*\\.(test))\\.jsx?$",
     "moduleNameMapper": {
       "static.config.js": "<rootDir>/src/static/__mocks__/static.config.mock.js",
-      "./path/to/static.config.js": "<rootDir>/src/static/__mocks__/static.config.mock.js"
+      "./path/to/static.config.js": "<rootDir>/src/static/__mocks__/static.config.mock.js",
+      "./path/to/configWithPluginWithOptions.mock.js": "<rootDir>/src/static/__mocks__/configWithPluginWithOptions.mock.js"
     },
     "setupFiles": [
       "<rootDir>/setupTests.js"

--- a/packages/react-static/src/static/__mocks__/configWithPluginWithOptions.mock.js
+++ b/packages/react-static/src/static/__mocks__/configWithPluginWithOptions.mock.js
@@ -1,0 +1,4 @@
+export default {
+  entry: 'path/to/entry/index.js',
+  plugins: [['mock-plugin', { mockOption: 'some-option' }]],
+}

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -149,8 +149,8 @@ export const buildConfig = async (config = {}) => {
   const resolvePlugin = originalLocation => {
     let options = {}
     if (Array.isArray(originalLocation)) {
-      originalLocation = originalLocation[0]
       options = originalLocation[1] || {}
+      originalLocation = originalLocation[0]
     }
 
     const location = [
@@ -201,10 +201,16 @@ export const buildConfig = async (config = {}) => {
           //
         }
       },
+      () => {
+        if (process.env.NODE_ENV === 'test') {
+          // Allow plugins to be mocked
+          return 'mock-plugin'
+        }
+      },
     ].reduce((prev, curr) => prev || curr(), null)
 
     // TODO: We have to do this because we don't have a good mock for process.cwd() :(
-    if (process.env.NODE_ENV !== 'test' && !location) {
+    if (!location) {
       throw new Error(
         `Oh crap! Could not find a plugin directory for the plugin: "${location}". We must bail!`
       )


### PR DESCRIPTION
## Description
Options can be provided to plugins by passing an array instead of
the plugin name, with as first element the plugin name, and an
options object as the second argument. However, this array was
destructured as follows:

      originalLocation = originalLocation[0]
      options = originalLocation[1] || {}

Because the first line overwrote `originalLocation` with the name
of the plugin, the second line would actually assign the second
character of that name to `options`, rather than the second element
of the array. Switching them around fixes that.


## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code
- [x] Added tests (see notes at the bottom)

## Motivation and Context
Plugins could not actually receive options. This PR fixes that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] My changes have tests around them

Note that I am not too satisfied with the way I structured the tests, especially the part where I modified the actual code to set a plug-in's name to `mock-plugin` when in the test environment (as opposed to undefined as used to be the case). I then mocked `extra-fs` to return `true` when checking whether the `mock-plugin` plugin exists, so that I could provide a mock for that plugin.

Unfortunately, I couldn't think of a better way to test this. If anyone knows of a better way I'm all ears, but otherwise I guess we'll have to make do with this.