### PR TITLE
Document the `renderToElement` hook

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,6 +15,7 @@ A `static.config.js` file is optional, but recommended at your project root to u
 - [Document](#document)
 - [webpack](#webpack)
 - [devServer](#devserver)
+- [renderToElement](#rendertoelement)
 - [renderToHtml](#rendertohtml)
 - [paths](#paths)
 - [onStart](#onstart)
@@ -234,6 +235,8 @@ export default {
 
 ### `renderToElement`
 
+**Warning:** This option will be removed in a future version. Please use the [Node hook API](https://github.com/Vinnl/react-static/tree/patch-3/docs/plugins#beforerendertoelement-function) instead.
+
 An optional function that can be used to override the process of rendering the base app component to an element
 
 - Arguments
@@ -255,11 +258,13 @@ export default {
 
 ### `renderToHtml`
 
-An optional function that can be used to customize the process of rendering your apps final react element to HTML.
+**Warning:** This option will be removed in a future version. Please use the [Node hook API](https://github.com/Vinnl/react-static/tree/patch-3/docs/plugins#beforerendertohtml-function) instead
+
+An optional function that can be used to customize the process of rendering your app's final react element to HTML.
 
 - Arguments
   - `render: Function`: A function that renders a react component to an html string
-  - `JSXElement`: the final react element (that has already been rendered via `<Comp />`) for your site that needs to be rendered to an HTML
+  - `JSXElement`: the final react element (that has [already been rendered](#rendertoelement) via `<Comp />`) for your site that needs to be rendered to an HTML
   - options{}: an options object
     - `meta`, a **mutable** object that is exposed to the optional Document component as a prop
     - `clientStats`, the webpack client stats generated from the "prod" stage


### PR DESCRIPTION
## Description
Adds documentation for the `renderToElement` hook, which I only found in the CHANGELOG for v6. Note that I'm not sure whether this is complete, e.g. whether `meta` is passed to this function as well.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed documentation

## Motivation and Context
It was undocumented.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Add docs
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] ~~My changes have tests around them~~
