### PR TITLE
fix css-loader 2.0 support

### DIFF
--- a/packages/react-static-plugin-css-modules/src/node.api.js
+++ b/packages/react-static-plugin-css-modules/src/node.api.js
@@ -22,7 +22,10 @@ export default (options = {}) => ({
         {
           ...cssLoader,
           loader: 'css-loader',
-          options: { exportOnlyLocals: true },
+          options: {
+            exportOnlyLocals: true,
+            ...options
+          },
         },
       ]
     } else {


### PR DESCRIPTION
## Description
CSS Loader 2.0 disables CSS Modules by default, so in the node build config, css module support is disabled and no mappings are exported. The `options` object needs to remain present in the node config, albeit with the addition of `exportOnlyLocals: true`.

## Changes/Tasks
- Added `...options` to css-loader options during node build stage.

## Motivation and Context
With css-loader v2 builds break without this change.
**No open issue for this**

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
