### PR TITLE
Update animated-routes example to animate properly.

### DIFF
--- a/docs/guides/animated-routes.md
+++ b/docs/guides/animated-routes.md
@@ -9,7 +9,7 @@ Animated Routes can be achieved so many different ways. In this example, we'll s
 import React from 'react'
 import { Root, Routes } from 'react-static'
 import { Link } from '@reach/router'
-import { Transition } from 'react-spring'
+import { Transition, animated } from 'react-spring'
 
 const App = () => (
   <Root>
@@ -22,17 +22,22 @@ const App = () => (
       <Routes>
         {({ routePath, getComponentForPath }) => {
           // Using the routePath as the key, both routes will render at the same time for the transition
-          const Comp = getComponentForPath(routePath)
-          // Get the
           return (
             <Transition
               native
-              keys={routePath}
+              items={routePath}
               from={{ transform: 'translateY(100px)', opacity: 0 }}
               enter={{ transform: 'translateY(0px)', opacity: 1 }}
               leave={{ transform: 'translateY(100px)', opacity: 0 }}
             >
-              {style => <Comp style={style} />}
+              {item => props => {
+                const Comp = getComponentForPath(item)
+                return (
+                  <animated.div style={props}>
+                    <Comp />
+                  </animated.div>
+                )
+              }}
             </Transition>
           )
         }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The example does not work with the latest version of react-sprint. See react-spring `Transition` usage http://react-spring.surge.sh/transition#/red The PR fixes the issue and the animation works properly. 

There is still an issue with `withRouteData` & `withSiteData` when navigating as the route that is on its way out looses its data due to a re-render. I was not able to fix that yet.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
Fixed animated-routes example code to work with latest react-spring version

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The animated-routes example did not work with the latest version of react-sprint.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
