### PR TITLE
Add ServerLocation during static render

### DIFF
--- a/packages/react-static/src/browser/components/Root.js
+++ b/packages/react-static/src/browser/components/Root.js
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Router as ReachRouter } from '@reach/router'
-
+import { Router as ReachRouter, ServerLocation } from '@reach/router'
 //
 import {
   routeInfoByPath,
@@ -8,10 +7,16 @@ import {
   registerTemplateForPath,
   plugins,
 } from '../'
-import { getBasePath, makeHookReducer } from '../utils'
+import { getBasePath, makePathAbsolute, makeHookReducer } from '../utils'
 import ErrorBoundary from './ErrorBoundary'
 import HashScroller from './HashScroller'
 import { withStaticInfo } from './StaticInfo'
+
+const LocationWrapper = ({ children, staticInfo }) => (typeof document === 'undefined') ? (
+  <ServerLocation url={makePathAbsolute(staticInfo.path)}>
+    {children}
+  </ServerLocation>
+) : children
 
 const DefaultPath = ({ render }) => render
 

--- a/packages/react-static/src/browser/components/Root.js
+++ b/packages/react-static/src/browser/components/Root.js
@@ -20,10 +20,12 @@ const LocationWrapper = ({ children, staticInfo }) => (typeof document === 'unde
 
 const DefaultPath = ({ render }) => render
 
-const DefaultRouter = ({ children, basepath }) => (
-  <ReachRouter basepath={basepath}>
-    <DefaultPath default render={children} />
-  </ReachRouter>
+const DefaultRouter = ({ children, basepath, staticInfo }) => (
+  <LocationWrapper staticInfo={staticInfo}>
+    <ReachRouter basepath={basepath}>
+      <DefaultPath default render={children} />
+    </ReachRouter>
+  </LocationWrapper>
 )
 
 const RouterHook = makeHookReducer(plugins, 'Router', { sync: true })


### PR DESCRIPTION
## Description
This adds a wrapper component for the default `ReachRouter` that conditionally adds the `ServerLocation` component when the route is being statically rendered.

## Changes/Tasks
- [x] Created `LocationWrapper` component
- [x] Added `LocationWrapper` to `DefaultRouter`

## Motivation and Context
Fixes #945. Reach Router requires the `ServerLocation` component to provide the route location information during static rendering. See: https://reach.tech/router/server-rendering

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
