### PR TITLE
fix lighthouse Accessibility

### DIFF
--- a/packages/react-static/src/static/RootComponents.js
+++ b/packages/react-static/src/static/RootComponents.js
@@ -9,7 +9,7 @@ export class DefaultDocument extends Component {
           <meta charSet="UTF-8" />
           <meta
             name="viewport"
-            content="width=device-width, initial-scale=1, maximum-scale=1, shrink-to-fit=no"
+            content="width=device-width, initial-scale=1, maximum-scale=5, shrink-to-fit=no"
           />
         </Head>
         <Body>{children}</Body>


### PR DESCRIPTION
`[user-scalable="no"] is used in the <meta name="viewport"> element or the [maximum-scale] attribute is less than 5.`

i think its safe to set the max scale to 5
