### PR TITLE
fix project name with spaces on 'react-static create' #951

### DIFF
--- a/packages/react-static/src/commands/create.js
+++ b/packages/react-static/src/commands/create.js
@@ -177,7 +177,7 @@ export default (async function create({ name, template, isCLI }) {
       }...`
     )
     // We install react-static separately to ensure we always have the latest stable release
-    execSync(`cd ${name} && ${isYarn ? 'yarn' : 'npm install'}`)
+    execSync(`cd "${name}" && ${isYarn ? 'yarn' : 'npm install'}`)
     console.log('')
   }
 
@@ -186,7 +186,7 @@ export default (async function create({ name, template, isCLI }) {
   console.log(`
   ${chalk.green('=> To get started:')}
 
-    cd ${name} ${
+    cd "${name}" ${
     !isCLI
       ? `&& ${
           isYarn


### PR DESCRIPTION
Adding \" on path name solves the problem

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrapped path name with " ", that way the project can be created in folders named like "my project" without breaking the application

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [ ] Changed code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/nozzle/react-static/issues/951
## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
