### PR TITLE
Fixed typo in README, tuturials -> tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ React-Static is a fast, lightweight, and powerful framework for building static-
 - Articles
   - [Introduction and Motivations behind React Static](https://medium.com/@tannerlinsley/%EF%B8%8F-introducing-react-static-a-progressive-static-site-framework-for-react-3470d2a51ebc)
   - [React Static v6!](https://medium.com/@tannerlinsley/react-static-v6-8dbe9fd202d4)
-- Videos & Tuturials
+- Videos & Tutorials
   - [Quick Start with Styled Components](https://www.youtube.com/watch?v=KvlTVZPlmgs) (20 min)
   - [Introducing React-Static! How it works and why we built it!](https://www.youtube.com/watch?v=OqbJ5swVpDQ) (80 min)
   - [Using React-Static to replace create-react-app](https://youtu.be/1pBzh7IM1s8) (5 min)


### PR DESCRIPTION
Spotted a minor typo in `README.md` while reading through React Static docs