### PR TITLE
Add prefetch disabling for specific Links

### DIFF
--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -88,7 +88,8 @@ function startPreloader() {
       const els = [].slice.call(document.getElementsByTagName('a'))
       els.forEach(el => {
         const href = el.getAttribute('href')
-        if (href) {
+        const shouldPrefetch = !(el.getAttribute('prefetch') === 'false')
+        if (href && shouldPrefetch) {
           onVisible(el, () => {
             prefetch(href)
           })


### PR DESCRIPTION
## Description
I've added one more check before prefetch is being done so that it can be disabled easily.
This feature was working fine in React-Static v5, but in v6 there's a new router it stopped working.

By adding `prefetch="false"` to a `<Link>` component we can prevent React-Static from prefetching this route.

Some documentation has to be added, but I wasn't sure where to put it.
Waiting for your suggestions.

## Motivation and Context
Without this change you cannot disable prefetching specific links.
It fixes an issue I've opened [here](https://github.com/nozzle/react-static/issues/970).

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
