### PR TITLE
Support non-js extensions (.jsx, .mjs, .ts, etc.)

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -129,6 +129,7 @@
     "testRegex": "(/__tests__/.*\\.(test))\\.jsx?$",
     "moduleNameMapper": {
       "static.config.js": "<rootDir>/src/static/__mocks__/static.config.mock.js",
+      "./path/to/static.config": "<rootDir>/src/static/__mocks__/static.config.mock.jsx",
       "./path/to/static.config.js": "<rootDir>/src/static/__mocks__/static.config.mock.js",
       "./path/to/configWithPluginWithOptions.mock.js": "<rootDir>/src/static/__mocks__/configWithPluginWithOptions.mock.js"
     },

--- a/packages/react-static/src/static/__mocks__/static.config.mock.jsx
+++ b/packages/react-static/src/static/__mocks__/static.config.mock.jsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+export default {
+  Document: ({ Html, Head, Body, children }) => (
+    <Html lang="en-US">
+      <Head>
+        <meta charSet="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Body>{children}</Body>
+    </Html>
+  ),
+}

--- a/packages/react-static/src/static/__tests__/getConfig.test.js
+++ b/packages/react-static/src/static/__tests__/getConfig.test.js
@@ -124,6 +124,14 @@ describe('getConfig', () => {
       })
     })
 
+    it('should find the configuration file using any supported extension', async () => {
+      // mapped by the moduleNameMapper in package.json -> src/static/__mocks__/static.config.jsx
+      const configuration = await getConfig('./path/to/static.config')
+
+      testConfiguration(configuration, defaultConfigProduction)
+      expect(configuration.Document).toBeInstanceOf(Function) // React component
+    })
+
     it('should pass on plugin options to those plugins', async () => {
       mockPlugin.mockReset()
       // mapped by the moduleNameMapper in package.json -> src/static/__mocks__/configWithPluginWithOptions.mock.js


### PR DESCRIPTION
## Description
This PR enhances the `getConfig.js` file to support non-js file extensions for all of the React Static config files:

- `static.config.js`
- `node.api.js`
- `browser.api.js`
- `src/index.js`

All of these files are now loaded via a function called `resolveModule()`, which first attempts to load the module via Node's built-in `require.resolve()`.  This will automatically support any module extension that's built into Node (i.e. `.js`, `.mjs`, `.node`, etc).  It will also support any extensions that have been registered via Node require hooks, such as `.jsx`, `.ts`, etc.

If `require.resolve()` is unable to find the module, then the `resolveModule()` function falls-back to `fs-extra` via `fs.pathExistsSync()`.  Even this fallback approach is enhanced though.  It now supports any of the extensions in `config.extensions`, rather than just `.js`.

## Changes/Tasks
- [x] Enhanced `getConfig.js` as described above
- [x] Added a new test to `getConfig.test.js` that loads a `static.config.jsx` file using the functionality described above
- [x] Added a mock `static.config.jsx` file that includes a React component (the `Document` option)

## Motivation and Context
This change allows people to use whatever file extensions they prefer (i.e. `.jsx` instead of `.js`).  This is actually required by some IDEs and text editors to get correct code highlighting and syntax support.  Many text editors only support JSX syntax in `.jsx` files.

It also adds support for TypeScript via [ts-node](https://www.npmjs.com/package/ts-node).  TS-Node is just a pass-through to Node.js, but it registers a require hook that adds support for TypeScript (`.ts` and `.tsx`) files.  Users can now seamlessly use TypeScript with React Static by using files like `static.config.ts` and `src/index.tsx`.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My changes have tests around them
