### PR TITLE
Added TypeScript definitions for `static.config.js` files

### DIFF
--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -8,6 +8,10 @@
 
 declare module 'react-static' {
   import * as React from 'react'
+  import { ComponentType, ReactNodeArray } from "react";
+  import { Configuration as WebpackDevServerConfig } from "webpack-dev-server";
+
+  type AnyReactComponent = ComponentType<Record<string, any>>;
 
   // Passing on helmet typings as "Head"
   import { Helmet } from 'react-helmet'
@@ -42,4 +46,78 @@ declare module 'react-static' {
   ): Promise<any>
 
   export const Prefetch: React.Component
+
+  /**
+   * @see https://github.com/nozzle/react-static/blob/master/docs/config.md
+   */
+  export interface ReactStaticConfig {
+    siteRoot?: string;
+    stagingSiteRoot?: string;
+    basePath?: string;
+    stagingBasePath?: string;
+    devBasePath?: string;
+    assetsPath?: string;
+    extractCssChunks?: boolean;
+    inlineCss?: boolean;
+    disablePreload?: boolean;
+    bundleAnalyzer?: boolean;
+    disableDuplicateRoutesWarning?: boolean;
+    outputFileRate?: number;
+    prefetchRate?: number;
+    maxThreads?: number;
+    minLoadTime?: number;
+    disableRoutePrefixing?: boolean;
+    paths?: PathsConfig;
+    babelExcludes?: RegExp[];
+    devServer?: WebpackDevServerConfig;
+    plugins?: Array<string | [string, object]>;
+    Document?: AnyReactComponent;
+    getRoutes?(flags: RouteFlags): Route[];
+    getSiteData?(flags: RouteFlags): any;
+    onStart?(args: OnStartArgs): void;
+    onBuild?(): void;
+  }
+
+  export interface PathsConfig {
+    root?: string;
+    src?: string;
+    temp?: string;
+    dist?: string;
+    devDist?: string;
+    public?: string;
+    assets?: string;
+    pages?: string;
+    plugins?: string;
+    nodeModules?: string;
+  }
+
+  export interface RouteFlags {
+    dev: boolean;
+  }
+
+  export interface Route {
+    path: string;
+    component?: string;
+    redirect?: string;
+    noindex?: boolean;
+    permalink?: string;
+    lastModified?: string;
+    priority?: number;
+    children?: Route[];
+    getData?(resolvedRoute: Route, flags: RouteFlags): any;
+  }
+
+  export interface DocumentProps {
+    Html: AnyReactComponent,
+    Head: AnyReactComponent,
+    Body: AnyReactComponent,
+    children: ReactNodeArray,
+    routeInfo: object;
+    stieData: object;
+    renderMeta: object;
+  }
+
+  export interface OnStartArgs {
+    devServerConfig: Readonly<WebpackDevServerConfig>;
+  }
 }


### PR DESCRIPTION
## Description
This PR just adds TypeScript definitions for the `static.config.js` file.

## Changes/Tasks
- [x] TypeScript definitions

## Motivation and Context
For users who are writing their `static.config` file in TypeScript, these definitions add type checking, code completion, etc.

For users who are writing their `static.config` file in plain JavaScript, but using a TypeScript-aware code editor (such as VSCode), these definitions add code-completion.  If they're using [`// @ts-check`](https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html), then they'll also get type checking.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
