### PR TITLE
Add switch to the Routes component to disable force update on location change. 

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -63,6 +63,12 @@ export default () => (
 
 The routes that will be rendered are the **routes** returned by the `getRoutes` function of this config.
 
+#### Props
+
+| Prop                   | type      | Default | description                                                       |
+| ---------------------- | --------- | ------- | ----------------------------------------------------------------- |
+| `disableUpdateOnLocationChange`      | `bool`    | false   | Toggles location changes from updating the component tree                                    |
+
 ##### Custom `Routes` Rendering
 
 Occasionally, you may need to render the automatic `<Routes>` component in a custom way. The most common use-case is illustrated in the [animated-routes](https://github.com/nozzle/react-static/tree/master/examples/animated-routes) example transitions. To do this, utilize a render prop:

--- a/packages/react-static/src/browser/components/Routes.js
+++ b/packages/react-static/src/browser/components/Routes.js
@@ -24,10 +24,13 @@ export default withStaticInfo(
   class Routes extends Component {
     static defaultProps = {
       Loader: Spinner,
+      disableUpdateOnLocationChange: false,
     }
     componentDidMount() {
       templateUpdated.cb = () => this.safeForceUpdate()
-      this.offLocationChange = onLocation(() => this.safeForceUpdate())
+      if (!this.props.disableUpdateOnLocationChange) {
+        this.offLocationChange = onLocation(() => this.safeForceUpdate())
+      }
     }
     componentWillUnmount() {
       this.unmounted = true


### PR DESCRIPTION
This PR adds a switch to the Routes component to disable force update on location change. This is useful for cases where you bring your own router and don't need the Routes component to force an update with url changes.

## Description
Adds a new default prop `disableUpdateOnLocationChange: false`

## Changes/Tasks
- [x] New default prop `disableUpdateOnLocationChange: false`

## Motivation and Context
The Routes component causes the next page to mount twice when inside a Reach Router. This can lead to bugs when doing working in `componentDidMount` like logging analytics. 
The router setup for reference
```javascript
<Router>
  <Routes default />
</Router>
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
