### PR TITLE
Enable routeData for the 404 page

### DIFF
--- a/packages/react-static/src/browser/components/RouteData.js
+++ b/packages/react-static/src/browser/components/RouteData.js
@@ -40,7 +40,7 @@ const RouteData = withStaticInfo(
 
         // If there was an error reported for this path, throw an error
         // unless there is data for the 404 page
-        if (routeError && !routeInfo) {
+        if (routeError && (!routeInfo || !routeInfo.data)) {
           throw new Error(
             `React-Static: <RouteData> could not find any data for this route: ${routePath}. If this is a dynamic route, please remove any reliance on RouteData or withRouteData from this routes components`
           )

--- a/packages/react-static/src/browser/components/RouteData.js
+++ b/packages/react-static/src/browser/components/RouteData.js
@@ -33,8 +33,14 @@ const RouteData = withStaticInfo(
       render() {
         const { children, Loader, routePath } = this.props
 
+        const routeError = routeErrorByPath[routePath]
+        const routeInfo = routeError
+          ? routeInfoByPath['404']
+          : routeInfoByPath[routePath]
+
         // If there was an error reported for this path, throw an error
-        if (routeErrorByPath[routePath]) {
+        // unless there is data for the 404 page
+        if (routeError && !routeInfo) {
           throw new Error(
             `React-Static: <RouteData> could not find any data for this route: ${routePath}. If this is a dynamic route, please remove any reliance on RouteData or withRouteData from this routes components`
           )
@@ -43,7 +49,7 @@ const RouteData = withStaticInfo(
         // If we haven't requested the routeInfo yet, or it's loading
         // Show a spinner and prefetch the data
         // TODO:suspense - This will become a suspense resource
-        if (!routeInfoByPath[routePath] || !routeInfoByPath[routePath].data) {
+        if (!routeInfo || !routeInfo.data) {
           ;(async () => {
             await Promise.all([
               prefetch(routePath, { priority: true }),
@@ -57,7 +63,7 @@ const RouteData = withStaticInfo(
         }
 
         // Otherwise, get it from the routeInfoByPath (subsequent client side)
-        return children(routeInfoByPath[routePath].data)
+        return children(routeInfo.data)
       }
     }
   )

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -179,6 +179,9 @@ export async function getRouteInfo(path, { priority } = {}) {
   } catch (err) {
     // If there was an error, mark the path as errored
     routeErrorByPath[path] = true
+    // Unless we already failed to find info for the 404 page,
+    // try to load info for the 404 page
+    if (path !== '404') return getRouteInfo('404', { priority })
     return
   }
   if (!priority) {


### PR DESCRIPTION
## Description

Allow routeData to be used by the 404 page

## Changes/Tasks
- Edited `getRouteInfo()` to look for info on the `404` route if an error occurred trying to find info (unless it was trying to find info on the `404` route and failed)
- Edited `RouteData` component to check for info on the `404` route if a `routeError` was found for the current route, and if so, to use the 404 route info.

## Motivation and Context

In version 5, it was possible to pass `routeData` to the 404 route. However, in version 6 this is no longer possible. Although the 404 route may access `siteData`, this is not sufficient for all use cases. It is very convenient to be able to pass `siteData` to the 404 route in unexpected situations, including: having a localized header/footer and wanting the header/footer to appear in the 404 route, without complicated the existing codebase by, for example, putting English header/footer data into `siteData` (where it would add unnecessary weight to routes that don't need it, etc.).

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
