### PR TITLE
Fix broken and missing links in docs and add site to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ React-Static is a fast, lightweight, and powerful framework for building static-
 - [mmxp.com.br - MadeiraMadeira Experience](https://www.mmxp.com.br/)
 - [Fullstack HQ: Web Design & Development Team in the Philippines](https://fullstackhq.com/)
 - [Be Clever: Games for kids and parents](https://beclever.cc)
-- [Stoplight: Best in class API Design, Docs, Mocking, and Testing](https://stoplight.io)([source](https://github.com/stoplightio/stoplight.io))
+- [Stoplight: Best in class API Design, Docs, Mocking, and Testing](https://stoplight.io) ([source](https://github.com/stoplightio/stoplight.io))
+- [WordFlow: Copywriting service](https://www.wordflow.ie/) ([source](https://github.com/nathanpower/wordflow-site))
 
 ## Quick Start
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -13,6 +13,8 @@ React Static ships with a plugin API to extend React Static's functionality.
   - [react-static-plugin-jss](/packages/react-static-plugin-jss) - Adds SSR support for JSS
 - React Alternatives
   - [react-static-plugin-preact](/packages/react-static-plugin-preact) - Adds preact support
+- React Router
+  - [react-static-plugin-react-router](/packages/react-static-plugin-react-router) - Adds react-router support
 - Type checking
   - [react-static-plugin-typescript](https://www.npmjs.com/package/react-static-plugin-typescript) - Allows you to write your components in TypeScript
 - Assets
@@ -103,7 +105,7 @@ export default pluginOptions => ({
 - [Transform your webpack config](/docs/plugins/node-api.md#webpack-functionfunction)
 - [Append JSX to the Head of the app](/docs/plugins/node-api.md#head-componentfunction)
 - [Customize your App's router](/docs/plugins/browser-api.md#router)
-- and more! 
+- and more!
 
 View the [browser API docs](/docs/plugins/browser-api.md) and the [node API docs](/docs/plugins/node-api.md) for full list of API methods that can be implemented.
 

--- a/packages/react-static-plugin-react-router/README.md
+++ b/packages/react-static-plugin-react-router/README.md
@@ -18,7 +18,7 @@ export default {
 }
 ```
 
-- Follow the [Dynamic Routes with React Router guide](/docs/guides/dynamic-routes-react-router) to configure your routes for both dynamic and static rendering
+- Follow the [Dynamic Routes with React Router guide](/docs/guides/dynamic-routes-react-router.md) to configure your routes for both dynamic and static rendering
 
 - (Optional) Configure the plugin:
 


### PR DESCRIPTION
The react-router plugin was not linked in the plugin section, and if you find it, the dynamic route link in that particular readme is broken.

Also took the opportunity to add a site to your list.

Thanks for your work on a fantastic project.