### PR TITLE
outputPath required for inlineCss

### DIFF
--- a/packages/react-static/src/static/exportRoute.js
+++ b/packages/react-static/src/static/exportRoute.js
@@ -127,6 +127,7 @@ export default (async function exportRoute({
     const appHtml = renderToString(comp)
     const { scripts, stylesheets, css } = flushChunks(clientStats, {
       chunkNames,
+      outputPath: config.paths.DIST,
     })
 
     clientScripts = scripts


### PR DESCRIPTION
## Description
The `outputPath` is required for `flushChunks` if `inlineCss: true` in `static.config.js`.

## Changes/Tasks
- [X] Changed code

## Motivation and Context
Fixes #971 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

