### PR TITLE
Fix loading of shared data

### DIFF
--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -208,14 +208,12 @@ export async function prefetchData(path, { priority } = {}) {
 
   // Defer to the cache first. In dev mode, this should already be available from
   // the call to getRouteInfo
-  if (routeInfo.fullData) {
-    return routeInfo.fullData
+  if (routeInfo.sharedData) {
+    return
   }
 
   // Request and build the props one by one
-  routeInfo.fullData = {
-    ...(routeInfo.data || {}),
-  }
+  routeInfo.sharedData = {}
 
   // Request the template and loop over the routeInfo.sharedHashesByProp, requesting each prop
   await Promise.all(
@@ -264,12 +262,9 @@ export async function prefetchData(path, { priority } = {}) {
       }
 
       // Otherwise, just set it as the key
-      routeInfo.fullData[key] = sharedDataByHash[hash]
+      routeInfo.sharedData[key] = sharedDataByHash[hash]
     })
   )
-
-  // Return the props
-  return routeInfo.fullData
 }
 
 export async function prefetchTemplate(path, { priority } = {}) {
@@ -311,13 +306,12 @@ export async function prefetch(path, options = {}) {
     requestPool.stop()
   }
 
-  let data
   if (type === 'data') {
-    data = await prefetchData(path, options)
+    await prefetchData(path, options)
   } else if (type === 'template') {
     await prefetchTemplate(path, options)
   } else {
-    ;[data] = await Promise.all([
+    await Promise.all([
       prefetchData(path, options),
       prefetchTemplate(path, options),
     ])
@@ -327,8 +321,6 @@ export async function prefetch(path, options = {}) {
   if (options.priority) {
     requestPool.start()
   }
-
-  return data
 }
 
 export function getCurrentRoutePath() {


### PR DESCRIPTION
## Description

* Make sure shared data is always merged with data at the same point to create more predictable behaviour
* Load shared data when necessary
* Remove confusing return value of prefetch methods (since it's mutating the route info, the return value is never needed)

## Motivation and Context

Fix nozzle/react-static#981

I've added some helper functions to determine whether or not the route info and/or its shared data should be loaded client-side. Although I feel like these might not be in the right place, but I'm not sure what would be a more appropriate place. Any suggestions?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
