### PR TITLE
Move build artifacts to artifacts dir (#1009)

### DIFF
--- a/packages/react-static/src/commands/bundle.js
+++ b/packages/react-static/src/commands/bundle.js
@@ -55,6 +55,12 @@ export default (async function bundle({
   await fs.remove(config.paths.DIST)
   timeEnd(chalk.green('=> [\u2713] Dist cleaned'))
 
+  // Remove the ARTIFACTS folder
+  console.log('=> Cleaning artifacts...')
+  time(chalk.green('=> [\u2713] Artifacts cleaned'))
+  await fs.remove(config.paths.BUILD_ARTIFACTS)
+  timeEnd(chalk.green('=> [\u2713] Artifacts cleaned'))
+
   // Empty ASSETS folder
   if (config.paths.ASSETS && config.paths.ASSETS !== config.paths.DIST) {
     console.log('=> Cleaning assets...')

--- a/packages/react-static/src/static/buildInfo.js
+++ b/packages/react-static/src/static/buildInfo.js
@@ -3,13 +3,13 @@ import fs from 'fs-extra'
 
 export function outputBuildInfo(config) {
   return fs.outputFileSync(
-    path.join(config.paths.DIST, 'react-static-build-config.json'),
+    path.join(config.paths.BUILD_ARTIFACTS, 'react-static-build-config.json'),
     JSON.stringify(config, null, 2)
   )
 }
 
 export function importBuildInfo(config) {
   return fs.readJson(
-    path.join(config.paths.DIST, 'react-static-build-config.json')
+    path.join(config.paths.BUILD_ARTIFACTS, 'react-static-build-config.json')
   )
 }

--- a/packages/react-static/src/static/clientStats.js
+++ b/packages/react-static/src/static/clientStats.js
@@ -3,14 +3,14 @@ import fs from 'fs-extra'
 
 export function outputClientStats(config, statsJSON) {
   return fs.outputFileSync(
-    path.join(config.paths.DIST, 'client-stats.json'),
+    path.join(config.paths.BUILD_ARTIFACTS, 'client-stats.json'),
     JSON.stringify(statsJSON, null, 2)
   )
 }
 
 export async function importClientStats(config) {
   const clientStats = await fs.readJson(
-    path.join(config.paths.DIST, 'client-stats.json')
+    path.join(config.paths.BUILD_ARTIFACTS, 'client-stats.json')
   )
   if (!clientStats) {
     throw new Error('No Client Stats Found')

--- a/packages/react-static/src/static/extractTemplates.js
+++ b/packages/react-static/src/static/extractTemplates.js
@@ -17,7 +17,7 @@ export default (async function extractTemplates(config, opts = {}) {
     }
     route.template = slash(
       path.relative(
-        config.paths.DIST,
+        config.paths.BUILD_ARTIFACTS,
         path.resolve(config.paths.ROOT, route.component)
       )
     )

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -30,6 +30,7 @@ export const buildConfig = async (config = {}) => {
     src: 'src',
     dist: 'dist',
     temp: 'tmp',
+    buildArtifacts: 'artifacts',
     devDist: 'tmp/dev-server',
     public: 'public',
     plugins: 'plugins',
@@ -60,6 +61,7 @@ export const buildConfig = async (config = {}) => {
     ASSETS,
     PLUGINS: resolvePath(config.paths.plugins),
     TEMP: resolvePath(config.paths.temp),
+    BUILD_ARTIFACTS: resolvePath(config.paths.buildArtifacts),
     PUBLIC: resolvePath(config.paths.public),
     NODE_MODULES: resolvePath(config.paths.nodeModules),
     EXCLUDE_MODULES:
@@ -136,11 +138,11 @@ export const buildConfig = async (config = {}) => {
   process.env.REACT_STATIC_PRELOAD_POLL_INTERVAL = config.preloadPollInterval
 
   process.env.REACT_STATIC_TEMPLATES_PATH = nodePath.join(
-    DIST,
+    paths.BUILD_ARTIFACTS,
     'react-static-templates.js'
   )
   process.env.REACT_STATIC_PLUGINS_PATH = nodePath.join(
-    DIST,
+    paths.BUILD_ARTIFACTS,
     'react-static-browser-plugins.js'
   )
   process.env.REACT_STATIC_UNIVERSAL_PATH = require.resolve(

--- a/packages/react-static/src/static/prepareRoutes.js
+++ b/packages/react-static/src/static/prepareRoutes.js
@@ -17,7 +17,7 @@ export default (async function prepareRoutes(config, opts = {}, cb = d => d) {
   if (!opts.silent) console.log('=> Building Routes...')
   // set the static routes
   process.env.REACT_STATIC_ROUTES_PATH = path.join(
-    config.paths.DIST,
+    config.paths.BUILD_ARTIFACTS,
     'react-static-templates.js'
   )
 

--- a/packages/react-static/templates/basic/.gitignore
+++ b/packages/react-static/templates/basic/.gitignore
@@ -7,6 +7,7 @@
 # production
 /dist
 /tmp
+/artifacts
 
 # misc
 .DS_Store

--- a/packages/react-static/templates/blank/.gitignore
+++ b/packages/react-static/templates/blank/.gitignore
@@ -7,6 +7,7 @@
 # production
 /dist
 /tmp
+/artifacts
 
 # misc
 .DS_Store

--- a/packages/react-static/templates/stress-test/.gitignore
+++ b/packages/react-static/templates/stress-test/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+artifacts
 .history
 .DS_store
 yarn-error.log


### PR DESCRIPTION
Move build artifacts from `dist/` to a new, `artifacts/` directory.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code

## Motivation and Context
Build artifacts with potentially private data were being grouped together with build files.
This change makes it so they are sent to `artifacts/` instead.

Closes #1009 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
