### PR TITLE
Fix registration of 404 route info

### DIFF
--- a/packages/react-static/src/browser/components/Root.js
+++ b/packages/react-static/src/browser/components/Root.js
@@ -6,6 +6,9 @@ import {
   sharedDataByHash,
   registerTemplateForPath,
   plugins,
+  getCurrentRoutePath,
+  routeErrorByPath,
+  templateErrorByPath,
 } from '../'
 import { getBasePath, makePathAbsolute, makeHookReducer } from '../utils'
 import ErrorBoundary from './ErrorBoundary'
@@ -59,6 +62,16 @@ const Root = withStaticInfo(
         // In SRR and production, synchronously register the template for the
         // initial path
         registerTemplateForPath(path, template)
+
+        // For a 404 route we will register the current route as invalid
+        if (path === '404') {
+          const currentPath = getCurrentRoutePath()
+          // As long as we didn't navigate to the 404.html page directly
+          if (currentPath !== '404') {
+            routeErrorByPath[currentPath] = true
+            templateErrorByPath[currentPath] = true
+          }
+        }
       }
     }
     render() {

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -179,9 +179,12 @@ export async function getRouteInfo(path, { priority } = {}) {
   } catch (err) {
     // If there was an error, mark the path as errored
     routeErrorByPath[path] = true
-    // Unless we already failed to find info for the 404 page,
+    // Unless we already fetched the 404 page,
     // try to load info for the 404 page
-    if (path !== '404') return getRouteInfo('404', { priority })
+    if (!routeInfoByPath['404'] && !routeErrorByPath['404']) {
+      return getRouteInfo('404', { priority })
+    }
+
     return
   }
   if (!priority) {
@@ -274,7 +277,9 @@ export async function prefetchTemplate(path, { priority } = {}) {
   const routeInfo = await getRouteInfo(path, { priority })
 
   if (routeInfo) {
-    registerTemplateForPath(path, routeInfo.template)
+    // Make sure to use the path as defined in the routeInfo object here.
+    // This will make sure 404 route info returned from getRouteInfo is handled correctly.
+    registerTemplateForPath(routeInfo.path, routeInfo.template)
   }
 
   // Preload the template if available
@@ -284,6 +289,12 @@ export async function prefetchTemplate(path, { priority } = {}) {
     templateErrorByPath[path] = true
     return
   }
+
+  // If we didn't no route info was return, there is nothing more to do here
+  if (!routeInfo) {
+    return
+  }
+
   if (!routeInfo.templateLoaded && Template.preload) {
     if (priority) {
       await Template.preload()


### PR DESCRIPTION
## Changes
* Make sure a 404 template is registered for the '404' path when prefetching (instead of the original path)
* Make sure the path for a non-existing route is registered as error when hydrating the initial state
* Handle undefined return value of the getRouteInfo method

## Motivation and Context
Fixes #1008 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
