### PR TITLE
Hard-cache babel config using `api.cache(true)`

### DIFF
--- a/packages/react-static/babel-preset.js
+++ b/packages/react-static/babel-preset.js
@@ -4,6 +4,8 @@ module.exports = (api, { external, modules, helpers } = {}) => {
   const { NODE_ENV, BABEL_ENV } = process.env
 
   const PRODUCTION = (BABEL_ENV || NODE_ENV) === 'production'
+  
+  api.cache(true)
 
   return {
     ...(external


### PR DESCRIPTION
## Description
Given that we only continuously compile during during dev, and given that the config only depends on `external` which isn't likely to change during development, a hard cache seems like the right solution.

## Motivation and Context
Fixes #1023

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
