### PR TITLE
Improve prefetchable route detection

### DIFF
--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -210,23 +210,18 @@ export function isPrefetchableRoute(path) {
     return false
   }
 
-  // script links
-  // eslint-disable-next-line
-  if (path.indexOf('javascript:') === 0) {
-    return false
-  }
-
   const self = document.location
   let link
 
   try {
-    link = new URL(path)
+    const baseURL = `${self.protocol}//${self.hostname + self.pathname}`
+    link = new URL(path, baseURL)
   } catch (e) {
-    // if a path is not parsable by URL its a local relative path
-    return true
+    // Return false on invalid URLs
+    return false
   }
 
-  // if the hostname/port/proto doesnt match its not a route link
+  // if the hostname/port/proto doesn't match its not a route link
   if (
     self.hostname !== link.hostname ||
     self.port !== link.port ||


### PR DESCRIPTION
## Description
* Don't rely on 'invalid' relative links, but check for hostname, protocol and port instead, fixing detection of absolute URLs without explicit protocol
* Removed redundant check for script links
* Added unit tests

## Motivation and Context
`//www.example.com` would be considered 'prefetchable' because it would throw an error, and all invalid URLs were considered 'prefetchable'. By adding the base URL this will be fixed, it will create a valid URL object, but the hostname will differ and therefor the link will not be considered 'prefetchable'.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
