### PR TITLE
Restore route data return value for prefetch

### DIFF
--- a/packages/react-static/src/browser/components/RouteData.js
+++ b/packages/react-static/src/browser/components/RouteData.js
@@ -4,6 +4,7 @@ import { prefetch, routeInfoByPath, routeErrorByPath } from '../'
 import Spinner from './Spinner'
 import { withStaticInfo } from './StaticInfo'
 import { withRoutePathContext } from './Routes'
+import { getFullRouteData } from '../utils'
 
 let instances = []
 
@@ -64,12 +65,9 @@ const RouteData = withStaticInfo(
 
         // Otherwise, get it from the routeInfoByPath (subsequent client side)
         // and merge it with the shared data
-        const fullData = {
-          ...routeInfo.data,
-          ...routeInfo.sharedData,
-        }
+        const routeData = getFullRouteData(routeInfo)
 
-        return children(fullData)
+        return children(routeData)
       }
     }
   )

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -5,6 +5,7 @@ import {
   getRoutePath,
   pathJoin,
   isPrefetchableRoute,
+  getFullRouteData,
 } from './utils'
 import onVisible from './utils/Visibility'
 
@@ -182,7 +183,8 @@ export async function getRouteInfo(path, { priority } = {}) {
     // Unless we already fetched the 404 page,
     // try to load info for the 404 page
     if (!routeInfoByPath['404'] && !routeErrorByPath['404']) {
-      return getRouteInfo('404', { priority })
+      getRouteInfo('404', { priority })
+      return
     }
 
     return
@@ -212,7 +214,7 @@ export async function prefetchData(path, { priority } = {}) {
   // Defer to the cache first. In dev mode, this should already be available from
   // the call to getRouteInfo
   if (routeInfo.sharedData) {
-    return
+    return getFullRouteData(routeInfo)
   }
 
   // Request and build the props one by one
@@ -268,6 +270,8 @@ export async function prefetchData(path, { priority } = {}) {
       routeInfo.sharedData[key] = sharedDataByHash[hash]
     })
   )
+
+  return getFullRouteData(routeInfo)
 }
 
 export async function prefetchTemplate(path, { priority } = {}) {
@@ -292,10 +296,10 @@ export async function prefetchTemplate(path, { priority } = {}) {
 
   // If we didn't no route info was return, there is nothing more to do here
   if (!routeInfo) {
-    return
+    return Template
   }
 
-  if (routeInfo && !routeInfo.templateLoaded && Template.preload) {
+  if (!routeInfo.templateLoaded && Template.preload) {
     if (priority) {
       await Template.preload()
     } else {
@@ -317,12 +321,13 @@ export async function prefetch(path, options = {}) {
     requestPool.stop()
   }
 
+  let data
   if (type === 'data') {
-    await prefetchData(path, options)
+    data = await prefetchData(path, options)
   } else if (type === 'template') {
     await prefetchTemplate(path, options)
   } else {
-    await Promise.all([
+    ;[data] = await Promise.all([
       prefetchData(path, options),
       prefetchTemplate(path, options),
     ])
@@ -332,6 +337,8 @@ export async function prefetch(path, options = {}) {
   if (options.priority) {
     requestPool.start()
   }
+
+  return data
 }
 
 export function getCurrentRoutePath() {

--- a/packages/react-static/src/browser/utils/__tests__/shared.test.js
+++ b/packages/react-static/src/browser/utils/__tests__/shared.test.js
@@ -8,6 +8,7 @@ import {
   trimTrailingSlashes,
   trimDoubleSlashes,
   makePathAbsolute,
+  getFullRouteData,
 } from '../'
 
 describe('browser/utils', () => {
@@ -136,6 +137,31 @@ describe('browser/utils', () => {
     })
     it('should make path absolute', () => {
       expect(makePathAbsolute('foo/bar')).toEqual('/foo/bar')
+    })
+  })
+  describe('getFullRouteData', () => {
+    it('should return the data merged with the shared data', () => {
+      const routeInfo = {
+        data: { foo: 'foo' },
+        sharedData: { bar: 'bar' },
+      }
+      const expected = { foo: 'foo', bar: 'bar' }
+      expect(getFullRouteData(routeInfo)).toEqual(expected)
+    })
+    it('should return the data when no shared data was available', () => {
+      const routeInfo = {
+        data: { foo: 'foo' },
+      }
+      const expected = { foo: 'foo' }
+      expect(getFullRouteData(routeInfo)).toEqual(expected)
+    })
+    it('should override the shared data with the route data for duplicate keys', () => {
+      const routeInfo = {
+        data: { foo: 'foo' },
+        sharedData: { foo: 'bar', bar: 'bar' },
+      }
+      const expected = { foo: 'foo', bar: 'bar' }
+      expect(getFullRouteData(routeInfo)).toEqual(expected)
     })
   })
 })

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -242,3 +242,10 @@ export function isPrefetchableRoute(path) {
 
   return true
 }
+
+export function getFullRouteData(routeInfo) {
+  return {
+    ...(routeInfo.sharedData ? routeInfo.sharedData : {}),
+    ...routeInfo.data,
+  }
+}


### PR DESCRIPTION
## Motivation and Context
Previously, in #1010 I had removed the return value of the `prefetch` method, since it was not used internally and seemed only confusing. Now I just realised this was actually a documented feature 😨 ... I restored the return value, making sure only for routes resolving in a 404  it will return `undefined`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
