### PR TITLE
Add synchronous getWebpackConfig method to node api.

### DIFF
--- a/packages/react-static/node/index.js
+++ b/packages/react-static/node/index.js
@@ -5,6 +5,7 @@ const { default: bundle } = require('../lib/commands/bundle')
 const { default: exporter } = require('../lib/commands/export')
 const { reloadRoutes } = require('../lib/static/webpack')
 const { default: makePageRoutes } = require('../lib/node/makePageRoutes')
+const { default: getWebpackConfig } = require('../lib/node/getWebpackConfig')
 const { normalizeRoutes } = require('../lib/static/getConfig')
 const { default: createSharedData } = require('../lib/static/createSharedData')
 
@@ -16,6 +17,7 @@ module.exports = {
   export: exporter,
   reloadRoutes,
   makePageRoutes,
+  getWebpackConfig,
   normalizeRoutes,
   createSharedData,
 }

--- a/packages/react-static/src/node/getWebpackConfig.js
+++ b/packages/react-static/src/node/getWebpackConfig.js
@@ -1,0 +1,9 @@
+import getConfig from '../static/getConfig'
+import { webpackConfig } from '../static/webpack'
+
+// Required so handle static.config.js defined as es module
+require('../utils/binHelper')
+
+export default (function getWebpackConfig(configPath, stage = 'dev') {
+  return webpackConfig({ config: getConfig(), stage })
+})

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -32,7 +32,7 @@ export { reloadRoutes }
 
 // Builds a compiler using a stage preset, then allows extension via
 // webpackConfigurator
-export async function webpackConfig({ config, stage }) {
+export function webpackConfig({ config, stage }) {
   let webpackConfig
   if (stage === 'dev') {
     webpackConfig = require('./webpack.config.dev').default({ config })
@@ -51,15 +51,12 @@ export async function webpackConfig({ config, stage }) {
 
   const defaultLoaders = getStagedRules({ config, stage })
 
-  const webpackHook = makeHookReducer(config.plugins, 'webpack')
-
-  webpackConfig = await webpackHook(webpackConfig, {
+  const webpackHook = makeHookReducer(config.plugins, 'webpack', { sync: true })
+  return webpackHook(webpackConfig, {
     config,
     stage,
     defaultLoaders,
   })
-
-  return webpackConfig
 }
 
 // Starts the development server


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added synchronous `getWebpackConfig` method to node api.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [X] Changed code

## Motivation and Context
I believe there are several benefits to providing this method, but it came to light as I attempted to get `eslint` working correctly with `react-static`.

The problem is that we use [eslint-import-resolver-webpack](https://www.npmjs.com/package/eslint-import-resolver-webpack) in order for eslint to be capable of resolving dependencies the same way in which webpack would. The only way to know how webpack would resolve, is to expose a `webpack.config.js` to `eslint-import-resolver-webpack`.

In my first attempts, I utilized the existing internal methods and took advantage of the fact that webpack allows exporting a promise: https://webpack.js.org/configuration/configuration-types/#exporting-a-promise.

Unfortunately, eslint requires running synchronously: https://github.com/benmosher/eslint-plugin-import/issues/883.

As I dug a little deeper into the codebase of react-static, I didn't see a compelling reason why the internal methods I was using were async.

This unfortunately is a breaking change, as the `config` and `webpack` hooks now require resolving synchronously. All documentation, and all implementations I have seen, currently resolve synchronously, so hopefully the collateral damage will be small.

I believe this change is a net win. Yes we are removing some functionality, but we are doing so in order to support a much more common use case.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My changes have tests around them
