### PR TITLE
Add custom data argument for route rebuilds

### DIFF
--- a/packages/react-static/src/commands/bundle.js
+++ b/packages/react-static/src/commands/bundle.js
@@ -17,6 +17,7 @@ export default (async function bundle({
   config: originalConfig,
   staging,
   debug,
+  data,
 } = {}) {
   // ensure ENV variables are set
   if (typeof process.env.NODE_ENV === 'undefined' && !debug) {
@@ -70,7 +71,7 @@ export default (async function bundle({
   }
 
   config = await prepareBrowserPlugins(config)
-  config = await prepareRoutes(config)
+  config = await prepareRoutes(config, { data })
   await extractTemplates(config)
   await generateTemplates(config)
 

--- a/packages/react-static/src/commands/start.js
+++ b/packages/react-static/src/commands/start.js
@@ -15,7 +15,7 @@ import { createIndexFilePlaceholder } from '../utils'
 let cleaned
 let indexCreated
 
-export default (async function start({ config: configPath, debug } = {}) {
+export default (async function start({ config: configPath, debug, data } = {}) {
   // ensure ENV variables are set
   if (typeof process.env.NODE_ENV === 'undefined') {
     process.env.NODE_ENV = 'development'
@@ -52,7 +52,7 @@ export default (async function start({ config: configPath, debug } = {}) {
 
     config = await prepareBrowserPlugins(config)
 
-    await prepareRoutes(config, { dev: true }, async config => {
+    await prepareRoutes(config, { dev: true, data }, async config => {
       await extractTemplates(config, { dev: true })
       await generateTemplates(config)
       reloadRoutes()

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -246,7 +246,7 @@ export async function startDevServer({ config }) {
   // Start the messages socket
   const socket = io()
 
-  resolvedReloadRoutes = async (paths, data) =>
+  resolvedReloadRoutes = async (paths, { data } = {}) =>
     prepareRoutes(config, { dev: true, silent: true, data }, async config => {
       if (!paths) {
         paths = config.routes.map(route => route.path)

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -25,7 +25,7 @@ const reloadRoutes = (...args) => {
     // Not ready yet, so just wait
     return
   }
-  resolvedReloadRoutes(...args)
+  return resolvedReloadRoutes(...args)
 }
 
 export { reloadRoutes }
@@ -246,16 +246,14 @@ export async function startDevServer({ config }) {
   // Start the messages socket
   const socket = io()
 
-  resolvedReloadRoutes = async paths => {
-    await prepareRoutes(config, { dev: true, silent: true }, async config => {
-      if (!paths) {
-        paths = config.routes.map(route => route.path)
-      }
-      paths = paths.map(getRoutePath)
-      reloadWebpackRoutes(config)
-      socket.emit('message', { type: 'reloadRoutes', paths })
-    })
-  }
+  resolvedReloadRoutes = async (paths, data) => prepareRoutes(config, { dev: true, silent: true, data }, async config => {
+    if (!paths) {
+      paths = config.routes.map(route => route.path)
+    }
+    paths = paths.map(getRoutePath)
+    reloadWebpackRoutes(config)
+    socket.emit('message', { type: 'reloadRoutes', paths })
+  })
 
   await new Promise((resolve, reject) => {
     devServer.listen(port, null, err => {

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -246,14 +246,15 @@ export async function startDevServer({ config }) {
   // Start the messages socket
   const socket = io()
 
-  resolvedReloadRoutes = async (paths, data) => prepareRoutes(config, { dev: true, silent: true, data }, async config => {
-    if (!paths) {
-      paths = config.routes.map(route => route.path)
-    }
-    paths = paths.map(getRoutePath)
-    reloadWebpackRoutes(config)
-    socket.emit('message', { type: 'reloadRoutes', paths })
-  })
+  resolvedReloadRoutes = async (paths, data) =>
+    prepareRoutes(config, { dev: true, silent: true, data }, async config => {
+      if (!paths) {
+        paths = config.routes.map(route => route.path)
+      }
+      paths = paths.map(getRoutePath)
+      reloadWebpackRoutes(config)
+      socket.emit('message', { type: 'reloadRoutes', paths })
+    })
 
   await new Promise((resolve, reject) => {
     devServer.listen(port, null, err => {


### PR DESCRIPTION
Adds a method for passing in custom data to `getRoutes()` in the node API commands. If this approach is approved, I can add docs and tests.

## Description

An example of passing custom data:
```
// Rebuilding from webhook (server.js)
reloadRoutes(null, { data: 'some token from webhook' })

...

// In static config
getRoutes: async ({ data: token }) => {
    const data = await Prismic.fetch({ token })
    return routes(data) // return routes array
},
```

## Changes/Tasks
- [x] Changed code
- [ ] Update docs
- [ ] Update tests

## Motivation and Context
This is useful for when you need data to change for each given rebuild. For example, Prismic live site previews that need to fetch data from a certain ref.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
