### PR TITLE
Add react-hot-loader as peer dependency

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -140,5 +140,8 @@
       "enzyme-to-json/serializer"
     ]
   },
-  "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
+  "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4",
+  "peerDependencies": {
+    "react-hot-loader": "^4.3.12"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10538,10 +10538,10 @@ react-helmet@^5.2.0:
     prop-types "^15.5.4"
     react-side-effect "^1.1.0"
 
-react-hot-loader@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.6.1.tgz#7b4ebbbf931d864e78b31c25eee813fcf1ecfa99"
-  integrity sha512-BrMa/zyVq7aeHa2TDG6cVFgMiUut6OHZ/RkPqVHovsFbo0VI8VX7qCz2dYTDHFc9HtVrSUbJGd9LpFPIWtExBg==
+react-hot-loader@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.7.1.tgz#1260b939297859cff35aff61412887a92c9b4275"
+  integrity sha512-OVq9tBndJ+KJWyWbj6kAkJbRVFx3Ykx+XOlndT3zyxAQMBFFygV+AS9RQi6Z2axkPIcEkuE5K6nkpcjlzR8I9w==
   dependencies:
     fast-levenshtein "^2.0.6"
     global "^4.3.0"


### PR DESCRIPTION
React-static doesn't work out of the box without react-hot-loader, so it should be listed as a peerDependency.

## Description
I added the version that's included in the template projects to the peerDependency field of react-static.

## Changes/Tasks
- [ ] Changed code

## Motivation and Context
This will make it easier to add react-static to a project without using a template, increasing flexibility.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
