### PR TITLE
Move node app build to artifacts folder

### DIFF
--- a/packages/react-static/src/static/exporter.js
+++ b/packages/react-static/src/static/exporter.js
@@ -22,7 +22,7 @@ export default async ({
   setIgnorePath(config.paths.DIST)
 
   const Comp = require(glob.sync(
-    path.resolve(config.paths.ASSETS, 'static.*.js')
+    path.resolve(config.paths.BUILD_ARTIFACTS, 'static-app.js')
   )[0]).default
   // Retrieve the document template
   const DocumentTemplate = config.Document || DefaultDocument

--- a/packages/react-static/src/static/exporter.threaded.js
+++ b/packages/react-static/src/static/exporter.threaded.js
@@ -20,7 +20,7 @@ process.on('message', async payload => {
 
     // Use the node version of the app created with webpack
     const Comp = require(glob.sync(
-      path.resolve(config.paths.ASSETS, 'static.*.js')
+      path.resolve(config.paths.BUILD_ARTIFACTS, 'static-app.js')
     )[0]).default
     // Retrieve the document template
     const DocumentTemplate = config.Document || DefaultDocument

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -37,7 +37,7 @@ function initCSSLoader() {
 }
 
 export default function({ stage, isNode }) {
-  let cssLoader = initCSSLoader(stage)
+  let cssLoader = initCSSLoader()
   if (stage === 'node' || isNode) {
     return {
       test: /\.css$/,

--- a/packages/react-static/src/static/webpack/rules/fileLoader.js
+++ b/packages/react-static/src/static/webpack/rules/fileLoader.js
@@ -1,4 +1,11 @@
-export default function() {
+export default function({ stage, isNode }) {
+  if (stage === 'node' || isNode) {
+    return {
+      loader: 'url-loader',
+      exclude: [/\.js$/, /\.html$/, /\.json$/],
+      // Don't generate extra files during node build
+    }
+  }
   return {
     loader: 'url-loader',
     exclude: [/\.js$/, /\.html$/, /\.json$/],

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -134,11 +134,13 @@ export default function({ config, isNode }) {
   if (!isNode) return result
 
   // Node only!!!
-  result.output.filename = 'static.[chunkHash:8].js'
+  result.output.filename = 'static-app.js'
+  result.output.path = config.paths.BUILD_ARTIFACTS
   result.output.libraryTarget = 'umd'
   result.optimization.minimize = false
   result.optimization.minimizer = []
   result.target = 'node'
+  result.devtool = false
   result.externals = [
     nodeExternals({
       whitelist: [


### PR DESCRIPTION

## Description
Moves the output of the "node" app build to the artifacts folder. I also added a change that ignores file size limits to the URL loader, but was considering ignoring these files entirely (curious about your thoughts on this).

## Changes/Tasks
- [x] Changed code

## Motivation and Context
Since this compiled app is only used by route exporters, moving it out of the build folder should make its purpose more explicit while saving space.

## Types of changes
- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
