### PR TITLE
node-api.md: fix link to webpack rules directory

### DIFF
--- a/docs/plugins/node-api.md
+++ b/docs/plugins/node-api.md
@@ -45,7 +45,7 @@ webpack: []Function(
 
 When `webpack` is passed an array of functions, they are applied in order from top to bottom and are each expected to return a new or modified config to use. They can also return a falsey value to opt out of the transformation and defer to the next function.
 
-By default, React Static's webpack toolchain compiles `.js` and `.css` files. Any other file that is not a `.js` `.json` or `.html` file is also processed with the `fileLoader` (images, fonts, etc.) and will move to `./dist` directory on build. The source for all default loaders can be found in [react-static/lib/webpack/rules/](https://github.com/nozzle/react-static/blob/master/src/webpack/rules).
+By default, React Static's webpack toolchain compiles `.js` and `.css` files. Any other file that is not a `.js` `.json` or `.html` file is also processed with the `fileLoader` (images, fonts, etc.) and will move to `./dist` directory on build. The source for all default loaders can be found in [react-static/packages/react-static/src/static/webpack/rules/](https://github.com/nozzle/react-static/tree/master/packages/react-static/src/static/webpack/rules).
 
 Our default loaders are organized like so:
 

--- a/docs/plugins/node-api.md
+++ b/docs/plugins/node-api.md
@@ -45,7 +45,7 @@ webpack: []Function(
 
 When `webpack` is passed an array of functions, they are applied in order from top to bottom and are each expected to return a new or modified config to use. They can also return a falsey value to opt out of the transformation and defer to the next function.
 
-By default, React Static's webpack toolchain compiles `.js` and `.css` files. Any other file that is not a `.js` `.json` or `.html` file is also processed with the `fileLoader` (images, fonts, etc.) and will move to `./dist` directory on build. The source for all default loaders can be found in [react-static/packages/react-static/src/static/webpack/rules/](https://github.com/nozzle/react-static/tree/master/packages/react-static/src/static/webpack/rules).
+By default, React Static's webpack toolchain compiles `.js` and `.css` files. Any other file that is not a `.js` `.json` or `.html` file is also processed with the `fileLoader` (images, fonts, etc.) and will move to `./dist` directory on build. The source for all default loaders can be found in [webpack/rules/ directory](https://github.com/nozzle/react-static/tree/master/packages/react-static/src/static/webpack/rules).
 
 Our default loaders are organized like so:
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes node-api documentation with a correct link to webpack rules directory.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [ ] Changed code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
