### PR TITLE
Update plugin resolution error message & docs

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -48,8 +48,8 @@ Order of execution:
 
 Plugins are resolved in this order:
 
-1.  Plugins with an absolute path. Eg. `~/path/to/my/plugin.js` would resolve to that path.
-2.  Plugins found in the `/plugins` directory of your project root. Eg. `myPlugin` would resolve to `/plugins/myPlugins.js`.
+1.  Plugins with an absolute path. Eg. `~/path/to/my/my-plugin` would resolve to that path.
+2.  Plugins found in the `/plugins` directory of your project root. Eg. `my-plugin` would resolve to `/plugins/my-plugin`.
 3.  Plugins found in `node_modules`. Eg. `react-static-plugin-emotion` would resolve to `node_modules/react-static-plugin-emotion`.
 
 ## Plugin Options

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -215,7 +215,7 @@ export const buildConfig = async (config = {}) => {
     // TODO: We have to do this because we don't have a good mock for process.cwd() :(
     if (!location) {
       throw new Error(
-        `Oh crap! Could not find a plugin directory for the plugin: "${location}". We must bail!`
+        `Oh crap! Could not find a plugin directory for the plugin: "${originalLocation}". We must bail!`
       )
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See following paragraphs

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Update plugin resolution error message
- [x] Update plugin resolution documentation

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- We will have an error with the following message if plugin wasn't resolved:
  ```Oh crap! Could not find a plugin directory for the plugin: "undefined". We must bail!```.
- > Plugins found in the /plugins directory of your project root. Eg. myPlugin would resolve to /plugins/myPlugins.js.

  `myPlugin` won't resolve to `myPlugin.js` because `originalLocation` isn't modified in [resolvePlugin](https://github.com/nozzle/react-static/blob/master/packages/react-static/src/static/getConfig.js#L152).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
