### PR TITLE
Add global.reloadAll only in development

### DIFF
--- a/packages/react-static/src/browser/components/RouteData.js
+++ b/packages/react-static/src/browser/components/RouteData.js
@@ -8,8 +8,10 @@ import { getFullRouteData } from '../utils'
 
 let instances = []
 
-global.reloadAll = () => {
-  instances.forEach(instance => instance.safeForceUpdate())
+if (process.env.REACT_STATIC_ENV === 'development') {
+  global.reloadAll = () => {
+    instances.forEach(instance => instance.safeForceUpdate())
+  }
 }
 
 const RouteData = withStaticInfo(


### PR DESCRIPTION
Ref https://github.com/nozzle/react-static/commit/e1bdabfb0424557bc06fb14123c8845420cb35ca#r32536231

## Description

Add a check for creating `global.reloadAll` only in development.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We shouldn't pollute the global scope in production with a useless function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
