### PR TITLE
Fix babel ignore path for build artifacts

### DIFF
--- a/packages/react-static/src/static/exporter.js
+++ b/packages/react-static/src/static/exporter.js
@@ -2,7 +2,6 @@
 
 const { setIgnorePath } = require('../utils/binHelper')
 
-import glob from 'glob'
 import path from 'path'
 
 import { DefaultDocument } from './RootComponents'
@@ -19,11 +18,12 @@ export default async ({
   const htmlProgress = progress(routes.length)
   // Use the node version of the app created with webpack
 
-  setIgnorePath(config.paths.DIST)
+  setIgnorePath(config.paths.BUILD_ARTIFACTS)
 
-  const Comp = require(glob.sync(
-    path.resolve(config.paths.BUILD_ARTIFACTS, 'static-app.js')
-  )[0]).default
+  const Comp = require(path.resolve(
+    config.paths.BUILD_ARTIFACTS,
+    'static-app.js'
+  )).default
   // Retrieve the document template
   const DocumentTemplate = config.Document || DefaultDocument
 


### PR DESCRIPTION
## Motivation and Context
The babel ignore path was not updated to the new `artifacts` folder, so the generated `static-app.js` was also parsed by Babel resulting in an extremely slow build.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
