### PR TITLE
Update docs for Node API config argument

### DIFF
--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -34,7 +34,7 @@ Creates a new react-static project.
 Starts the development server.
 
 - Arguments
-  - `config: object || string` - The config object to use, or the path of the `static.config.js` file you wish to use.
+  - `config: string` - The path of the `static.config.js` file you wish to use.
 - Returns a `Promise` that will **never resolve**. The process must be exited by the user to stop the server.
 
 ### `build`
@@ -42,7 +42,7 @@ Starts the development server.
 Builds your site for production. Outputs to a `dist` directory in your project.
 
 - Arguments
-  - `config: object || string` - The config object to use, or the path of the `static.config.js` file you wish to use.
+  - `config: string` - The path of the `static.config.js` file you wish to use.
   - `staging` - When `true`, no siteRoot replacement or absolute URL optimizations are performed, allowing a production build of your site to function on localhost more easily. Use this argument to test a production build locally.
   - `debug` - When `true`, your build will **not** be `uglified` allowing you to debug production errors (as long as they are unrelated to minification or uglification)
 - Returns a `Promise`


### PR DESCRIPTION
The Node API no longer supports passing a configuration object in v6. This updates the docs to reflect that change.

## Description
<!--- Describe your changes in detail -->

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed docs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):
<!--- If not delete the sub-heading above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My changes have tests around them
