### PR TITLE
 Return promise from reloadRoutes

### DIFF
--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -49,7 +49,11 @@ Builds your site for production. Outputs to a `dist` directory in your project.
 
 ### `reloadRoutes`
 
-Intended for use in your `static.config.js` during development. When called it will rebuild all of your your routes and routeData by calling `config.getRoutes()` again. Any new routes or data returned will be hot-reloaded into your running development application. Its main use cases are very applicable if your routes or routeData are changing constantly during development and you do not want to restart the dev server. You can use this method to reload when local files are changed, update at a set timing interval, or even subscribe to an event stream from an API or CMS.
+Intended for use in your `static.config.js` during development. When called it will rebuild all of your routes and routeData by calling `config.getRoutes()` again. Any new routes or data returned will be hot-reloaded into your running development application. Its main use cases are very applicable if your routes or routeData are changing constantly during development and you do not want to restart the dev server. You can use this method to reload when local files are changed, update at a set timing interval, or even subscribe to an event stream from an API or CMS.
+
+- Arguments
+  - `paths: Array` - The paths to reload (defaults to all).
+- Returns a `Promise`
 
 Example:
 

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -25,7 +25,7 @@ const reloadRoutes = (...args) => {
     // Not ready yet, so just wait
     return
   }
-  resolvedReloadRoutes(...args)
+  return resolvedReloadRoutes(...args)
 }
 
 export { reloadRoutes }
@@ -247,7 +247,7 @@ export async function startDevServer({ config }) {
   const socket = io()
 
   resolvedReloadRoutes = async paths => {
-    await prepareRoutes(config, { dev: true, silent: true }, async config => {
+    return prepareRoutes(config, { dev: true, silent: true }, async config => {
       if (!paths) {
         paths = config.routes.map(route => route.path)
       }

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -246,8 +246,8 @@ export async function startDevServer({ config }) {
   // Start the messages socket
   const socket = io()
 
-  resolvedReloadRoutes = async paths => {
-    return prepareRoutes(config, { dev: true, silent: true }, async config => {
+  resolvedReloadRoutes = async paths =>
+    prepareRoutes(config, { dev: true, silent: true }, async config => {
       if (!paths) {
         paths = config.routes.map(route => route.path)
       }
@@ -255,7 +255,6 @@ export async function startDevServer({ config }) {
       reloadWebpackRoutes(config)
       socket.emit('message', { type: 'reloadRoutes', paths })
     })
-  }
 
   await new Promise((resolve, reject) => {
     devServer.listen(port, null, err => {


### PR DESCRIPTION
Makes `reloadRoutes` return a promise that resolves when routes are reloaded.

## Description

`reloadRoutes` now returns the promise returned by the inner `resolvedReloadRoutes`, instead of returning `undefined`.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code
- [x] Changed docs

## Motivation and Context

Because route reloading is an async process, it's important to know when it's complete to accomplish a further action. For example, when using a preview app I might want to wait to redirect to the app until it's ready (when the routes have reloaded).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

_Note:_ there's a possibility that this is a breaking change, if someone has some code that relies on the function returning `undefined`. But I think this is highly unlikely.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them

_Note_: I'm not quite sure what the `paths` argument is for- I took a stab at it in the docs, but let me know if I misunderstood it.