### PR TITLE
Fix shared route data for 404 pages

### DIFF
--- a/packages/react-static/src/browser/components/RouteData.js
+++ b/packages/react-static/src/browser/components/RouteData.js
@@ -55,7 +55,7 @@ const RouteData = withStaticInfo(
         if (shouldLoadData(routeInfo)) {
           ;(async () => {
             await Promise.all([
-              prefetch(routePath, { priority: true }),
+              prefetch(routeInfo.path, { priority: true }),
               new Promise(resolve =>
                 setTimeout(resolve, process.env.REACT_STATIC_MIN_LOAD_TIME)
               ),


### PR DESCRIPTION
## Description
When fetching shared data for 404 pages we should use the path to the 404 instead of the original path

## Motivation and Context
Currently react-static will fail to load the shared data for 404 pages when navigating from another page, and it will simply remain in a loading state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
