### PR TITLE
Include port in base url when matching templates

### DIFF
--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -204,17 +204,22 @@ export function getBasePath() {
     : process.env.REACT_STATIC_BASE_PATH
 }
 
+function buildBaseURL (baseLocation) {
+  const portPostfix = baseLocation.port ? `:${ baseLocation.port }` : ''
+  return `${baseLocation.protocol}//${baseLocation.hostname}${portPostfix}${baseLocation.pathname}`
+}
+
 export function isPrefetchableRoute(path) {
   // when rendering static pages we dont need this et all
   if (isSSR()) {
     return false
   }
 
-  const self = document.location
+  const baseLocation = document.location
   let link
 
   try {
-    const baseURL = `${self.protocol}//${self.hostname + self.pathname}`
+    const baseURL = buildBaseURL(baseLocation)
     link = new URL(path, baseURL)
   } catch (e) {
     // Return false on invalid URLs
@@ -223,9 +228,9 @@ export function isPrefetchableRoute(path) {
 
   // if the hostname/port/proto doesn't match its not a route link
   if (
-    self.hostname !== link.hostname ||
-    self.port !== link.port ||
-    self.protocol !== link.protocol
+    baseLocation.hostname !== link.hostname ||
+    baseLocation.port !== link.port ||
+    baseLocation.protocol !== link.protocol
   ) {
     return false
   }


### PR DESCRIPTION
Includes `port` in the base URL definition when template matching. 

## Description

Fixes a bug where routes weren't being matched correctly when using `localhost` (all routes returning 404). This was occurring because the port was being dropped from the base url definition.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] Changed code

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My changes have tests around them
