### PR TITLE
Add `getWebpackConfig` and `getWebpackConfigSync` methods to node API

### DIFF
--- a/packages/react-static/node/index.js
+++ b/packages/react-static/node/index.js
@@ -5,6 +5,10 @@ const { default: bundle } = require('../lib/commands/bundle')
 const { default: exporter } = require('../lib/commands/export')
 const { reloadRoutes } = require('../lib/static/webpack')
 const { default: makePageRoutes } = require('../lib/node/makePageRoutes')
+const { default: getWebpackConfig } = require('../lib/node/getWebpackConfig')
+const {
+  default: getWebpackConfigSync,
+} = require('../lib/node/getWebpackConfigSync')
 const { normalizeRoutes } = require('../lib/static/getConfig')
 const { default: createSharedData } = require('../lib/static/createSharedData')
 
@@ -16,6 +20,8 @@ module.exports = {
   export: exporter,
   reloadRoutes,
   makePageRoutes,
+  getWebpackConfig,
+  getWebpackConfigSync,
   normalizeRoutes,
   createSharedData,
 }

--- a/packages/react-static/src/browser/utils/index.js
+++ b/packages/react-static/src/browser/utils/index.js
@@ -143,6 +143,9 @@ export function makeHookReducer(plugins = [], hook, { sync } = {}) {
     return (value, opts) =>
       hooks.reduce((prev, hook) => {
         const next = hook(prev, opts)
+        if (next instanceof Promise) {
+          throw new Error('Cannot run async hooks in sync mode.')
+        }
         return typeof next !== 'undefined' ? next : prev
       }, value)
   }

--- a/packages/react-static/src/node/getWebpackConfig.js
+++ b/packages/react-static/src/node/getWebpackConfig.js
@@ -1,0 +1,13 @@
+import getConfig from '../static/getConfig'
+import { webpackConfig } from '../static/webpack'
+
+// Required so handle static.config.js defined as es module
+require('../utils/binHelper')
+
+export default (function getWebpackConfig(configPath, stage = 'dev') {
+  return new Promise(resolve =>
+    getConfig(configPath, staticConfig =>
+      resolve(webpackConfig({ config: staticConfig, stage }))
+    )
+  )
+})

--- a/packages/react-static/src/node/getWebpackConfigSync.js
+++ b/packages/react-static/src/node/getWebpackConfigSync.js
@@ -1,0 +1,10 @@
+import getConfig from '../static/getConfig'
+import { webpackConfig } from '../static/webpack'
+
+// Required so handle static.config.js defined as es module
+require('../utils/binHelper')
+
+export default (function getWebpackConfigSync(configPath, stage = 'dev') {
+  const staticConfig = getConfig(configPath, undefined, { sync: true })
+  return webpackConfig({ config: staticConfig, stage, sync: true })
+})

--- a/packages/react-static/src/static/__tests__/webpack.test.js
+++ b/packages/react-static/src/static/__tests__/webpack.test.js
@@ -1,0 +1,54 @@
+import { webpackConfig } from '../webpack'
+import staticConfig from '../__mocks__/defaultConfigDevelopment.mock'
+
+const createConfigWithWebpackHook = hook => {
+  const hooks = { webpack: hook }
+  return Object.assign({}, staticConfig, { plugins: [{ hooks }] })
+}
+
+describe('webpack', () => {
+  describe('when called synchronously', () => {
+    it('should return after executing plugin hooks sync', () => {
+      const config = createConfigWithWebpackHook(wpConfig =>
+        Object.assign(wpConfig, { mode: 'development' })
+      )
+
+      const myWebpackConfig = webpackConfig({
+        config,
+        stage: 'prod',
+        sync: true,
+      })
+
+      expect(myWebpackConfig.mode).toBe('development')
+    })
+
+    it('should throw if plugin hooks execute async', () => {
+      const config = createConfigWithWebpackHook(wpConfig =>
+        Promise.resolve(Object.assign(wpConfig, { mode: 'development' }))
+      )
+
+      expect(() =>
+        webpackConfig({
+          config,
+          stage: 'prod',
+          sync: true,
+        })
+      ).toThrow('Cannot run async hooks in sync mode')
+    })
+  })
+
+  describe('when called asynchronously', () => {
+    it('should resolve after executing plugin hooks async', async () => {
+      const config = createConfigWithWebpackHook(wpConfig =>
+        Promise.resolve(Object.assign(wpConfig, { mode: 'development' }))
+      )
+
+      const myWebpackConfig = await webpackConfig({
+        config,
+        stage: 'prod',
+      })
+
+      expect(myWebpackConfig.mode).toBe('development')
+    })
+  })
+})

--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -32,7 +32,7 @@ export { reloadRoutes }
 
 // Builds a compiler using a stage preset, then allows extension via
 // webpackConfigurator
-export async function webpackConfig({ config, stage }) {
+export function webpackConfig({ config, stage, sync }) {
   let webpackConfig
   if (stage === 'dev') {
     webpackConfig = require('./webpack.config.dev').default({ config })
@@ -51,15 +51,13 @@ export async function webpackConfig({ config, stage }) {
 
   const defaultLoaders = getStagedRules({ config, stage })
 
-  const webpackHook = makeHookReducer(config.plugins, 'webpack')
+  const webpackHook = makeHookReducer(config.plugins, 'webpack', { sync })
 
-  webpackConfig = await webpackHook(webpackConfig, {
+  return webpackHook(webpackConfig, {
     config,
     stage,
     defaultLoaders,
   })
-
-  return webpackConfig
 }
 
 // Starts the development server


### PR DESCRIPTION
## Description
Add `getWebpackConfig` and `getWebpackConfigSync` methods to node API. Based off of discussions in #1036.

## Changes/Tasks
<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [X] Changed code

## Motivation and Context
In short, provide better support for `eslint`. Read #1036 for full context.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] My changes have tests around them
