### PR TITLE
prevent source code provisioning in release build

### DIFF
--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -125,7 +125,7 @@ function common(config) {
       new CaseSensitivePathsPlugin(),
       config.bundleAnalyzer && new BundleAnalyzerPlugin(),
     ].filter(d => d),
-    devtool: undefined,
+    devtool: false,
   }
 }
 

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -87,7 +87,7 @@ function common(config) {
           cache: true,
           parallel: true,
           exclude: /\.min\.js/,
-          sourceMap: true,
+          sourceMap: false,
           terserOptions: {
             ie8: false,
             mangle: { safari10: true },
@@ -125,7 +125,7 @@ function common(config) {
       new CaseSensitivePathsPlugin(),
       config.bundleAnalyzer && new BundleAnalyzerPlugin(),
     ].filter(d => d),
-    devtool: 'source-map',
+    devtool: undefined,
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Currently source code is deployed to the server even after `yarn build`

## Description
changed some flags in webpack.config.prod.js
