### PR TITLE
makes sure animated example works correctly with the default App.tsx

### DIFF
--- a/docs/guides/animated-routes.md
+++ b/docs/guides/animated-routes.md
@@ -2,7 +2,7 @@
 
 Animated Routes can be achieved so many different ways. In this example, we'll stick to something simple and use the `react-spring` package.
 
-- Install the `react-spring` module using npm or yarn
+- Install the `react-spring@7` module using npm or yarn
 - Use the `Routes` component's child-as-a-function api to animate between routes:
 
 ```javascript
@@ -18,31 +18,31 @@ const App = () => (
       <Link to="/about">About</Link>
       <Link to="/blog">Blog</Link>
     </nav>
-    <div className="content">
-      <Routes>
-        {({ routePath, getComponentForPath }) => {
-          // Using the routePath as the key, both routes will render at the same time for the transition
-          return (
-            <Transition
-              native
-              items={routePath}
-              from={{ transform: 'translateY(100px)', opacity: 0 }}
-              enter={{ transform: 'translateY(0px)', opacity: 1 }}
-              leave={{ transform: 'translateY(100px)', opacity: 0 }}
-            >
-              {item => props => {
-                const Comp = getComponentForPath(item)
-                return (
+    <Routes>
+      {({ routePath, getComponentForPath }) => {
+        // Using the routePath as the key, both routes will render at the same time for the transition
+        return (
+          <Transition
+            native
+            items={routePath}
+            from={{ transform: 'translateY(100px)', opacity: 0 }}
+            enter={{ transform: 'translateY(0px)', opacity: 1 }}
+            leave={{ transform: 'translateY(100px)', opacity: 0 }}
+          >
+            {item => props => {
+              const Comp = getComponentForPath(item)
+              return (
+                <div className="content" style={{ position: 'absolute' }}>
                   <animated.div style={props}>
                     <Comp />
                   </animated.div>
-                )
-              }}
-            </Transition>
-          )
-        }}
-      </Routes>
-    </div>
+                </div>
+              )
+            }}
+          </Transition>
+        )
+      }}
+    </Routes>
   </Root>
 )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
the latest react-spring does not have the Transition component API and also Transition duplicates the html it is applied on, and this does create weird jumping of the content unless `position: absolute` is applied

## Motivation and Context
Make the example work correctly with the default html structure



