### PR TITLE
fix corejs warning for @babel/preset-env

### DIFF
--- a/packages/react-static/babel-preset.js
+++ b/packages/react-static/babel-preset.js
@@ -25,6 +25,7 @@ module.exports = (api, { external, modules, helpers } = {}) => {
               },
               useBuiltIns: 'entry',
               modules,
+              corejs: 2
             },
           ]
         : [


### PR DESCRIPTION
see https://github.com/gatsbyjs/gatsby/pull/12781/files
