### PR TITLE
Add note about requirement of using Suspense with useSiteData()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -136,6 +136,8 @@ export default () => {
 }
 ```
 
+Note: Make sure to wrap components using `useSiteDate()` with react's `<Suspense fallback="..."></Suspense>`. More information on the subject is available [here](https://reactjs.org/docs/react-api.html#reactsuspense).
+
 ## `Head`
 
 `Head` is a react component for managing tags in the document's `head`. Use it to update meta tags, title tags, etc.


### PR DESCRIPTION
## Description
Added note about Suspense dependency for useSiteData() hook. 
Added link to Suspense section in React's documentation.

## Changes/Tasks
- [ ] Changed code

## Motivation and Context
Newcomers can be confused with the error about missing Suspense barrier. It should be explicitly stated in the manual. 

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
