### PR TITLE
Fix for broken reloadClientData()

### DIFF
--- a/packages/react-static/src/browser/hooks/useSiteData.js
+++ b/packages/react-static/src/browser/hooks/useSiteData.js
@@ -16,6 +16,8 @@ export const useSiteData = () => {
   const [_, setCount] = useState(0)
   useEffect(() =>
     onReloadClientData(() => {
+      siteDataPromise = null
+      siteDataReady = false
       setCount(old => old + 1)
     })
   )

--- a/packages/react-static/src/static/webpack/runDevServer.js
+++ b/packages/react-static/src/static/webpack/runDevServer.js
@@ -8,11 +8,17 @@ import makeWebpackConfig from './makeWebpackConfig'
 import getRouteData from '../getRouteData'
 import plugins from '../plugins'
 import { findAvailablePort, time, timeEnd } from '../../utils'
+import fetchSiteData from '../fetchSiteData'
 
 let devServer
 let latestState
 let buildDevRoutes = () => {}
-let reloadClientData = () => {}
+let _reloadClientData = null
+function reloadClientData() {
+  if (_reloadClientData) {
+    return _reloadClientData()
+  }
+}
 
 export { reloadClientData }
 
@@ -214,7 +220,8 @@ If this is a dynamic route, consider adding it to the prefetchExcludes list:
   // Start the messages socket
   const socket = io()
 
-  reloadClientData = () => {
+  _reloadClientData = async () => {
+    latestState = await fetchSiteData(latestState)
     socket.emit('message', { type: 'reloadClientData' })
   }
 


### PR DESCRIPTION
## Description
In the original version importing `reloadClientData` inside **static.config.js** end up with an empty function declared [here](https://github.com/nozzle/react-static/blob/daf2d6bd17c3365d22beee086d0fb79e7431ec91/packages/react-static/src/static/webpack/runDevServer.js#L15) which is substituted [here](https://github.com/nozzle/react-static/blob/daf2d6bd17c3365d22beee086d0fb79e7431ec91/packages/react-static/src/static/webpack/runDevServer.js#L217) after socket creation, but substituted version can't be propagated to imports made before the substitution. 
Fixed version exports a wrapper function which will call up-to-date version of `reloadClientData()`.

The second part of the fix is dedicated to invalidating `siteData` inside `onReloadClientData()` handler of `useSiteData()` hook. This ensures that `siteData` is always reloaded on `reloadClientData()` call.

The pull-request is only a proof of concept. I will be surprised if it does not break anything.

## Changes/Tasks
- [x] Changed code

## Motivation and Context
Fix reloading siteData changes via `reloadClientData()`

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
