### PR TITLE
templates using react-static@7.0.0 not HMRing the CSS, upgrade to 7.0.5

### DIFF
--- a/packages/react-static/src/browser/components/Root.js
+++ b/packages/react-static/src/browser/components/Root.js
@@ -46,10 +46,10 @@ export function Root({ children }) {
           {`An internal error occured!
 
 ${
-            process.env.NODE_ENV === 'production'
-              ? 'Please see the console for more details.'
-              : error.stack
-          }
+  process.env.NODE_ENV === 'production'
+    ? 'Please see the console for more details.'
+    : error.stack
+}
           `}
         </pre>
       ) : (

--- a/packages/react-static/src/browser/hooks/usePrefetch.js
+++ b/packages/react-static/src/browser/hooks/usePrefetch.js
@@ -4,15 +4,12 @@ import { prefetch } from '../'
 import onVisible from '../utils/Visibility'
 
 export const usePrefetch = (path, ref = useRef()) => {
-  useEffect(
-    () => {
-      if (!ref.current) {
-        return
-      }
-      onVisible(ref.current, () => prefetch(getRoutePath(path)))
-    },
-    [ref.current, path]
-  )
+  useEffect(() => {
+    if (!ref.current) {
+      return
+    }
+    onVisible(ref.current, () => prefetch(getRoutePath(path)))
+  }, [ref.current, path])
 
   return ref
 }

--- a/packages/react-static/src/commands/export.js
+++ b/packages/react-static/src/commands/export.js
@@ -46,16 +46,16 @@ export default async (state = {}) => {
   console.log(`
 Your app is now exported! Here's what we suggest doing next:
 ${
-    staging
-      ? `
+  staging
+    ? `
 - Test your app locally
   - ${chalk.green(
     'serve dist -p 3000'
   )} (or your preferred static server utility)`
-      : `
+    : `
 - Upload your 'dist' directory to your favorite static host! We recommend using Netlify:
   - ${chalk.green('npx netlify-cli deploy')}`
-  }
+}
 - Analyze your app's webpack bundles
   - ${chalk.green('react-static bundle --analyze')}
 `)

--- a/packages/react-static/src/static/generateTemplates.js
+++ b/packages/react-static/src/static/generateTemplates.js
@@ -16,8 +16,8 @@ export default async state => {
 
   const file = `
 ${
-    process.env.NODE_ENV === 'production'
-      ? `
+  process.env.NODE_ENV === 'production'
+    ? `
 import React from 'react'
 import universal, { setHasBabelPlugin } from '${reactStaticUniversalPath}'
 
@@ -33,23 +33,21 @@ const universalOptions = {
 }
 
 ${templates
-          .map((template, index) => {
-            let chunkName = ''
+  .map((template, index) => {
+    let chunkName = ''
 
-            // relative resolving produces the wrong path, a "../" is missing
-            // as the files looks equal, we simple use an absolute path then
+    // relative resolving produces the wrong path, a "../" is missing
+    // as the files looks equal, we simple use an absolute path then
 
-            if (!paths.DIST.startsWith(paths.ROOT)) {
-              chunkName = `/* webpackChunkName: "${chunkNameFromFile(
-                template
-              )}" */`
-            }
+    if (!paths.DIST.startsWith(paths.ROOT)) {
+      chunkName = `/* webpackChunkName: "${chunkNameFromFile(template)}" */`
+    }
 
-            return `const t_${index} = universal(import('${template}'${chunkName}), universalOptions)
+    return `const t_${index} = universal(import('${template}'${chunkName}), universalOptions)
       t_${index}.template = '${template}'
       `
-          })
-          .join('\n')}
+  })
+  .join('\n')}
 
 // Template Map
 export default {
@@ -58,7 +56,7 @@ export default {
 // Not Found Template
 export const notFoundTemplate = ${JSON.stringify(templates[0])}
 `
-      : `
+    : `
   
 // Template Map
 export default {
@@ -69,7 +67,7 @@ export default {
 
 export const notFoundTemplate = '${templates[0]}'
 `
-  }
+}
 `
 
   const dynamicRoutesPath = path.join(process.env.REACT_STATIC_TEMPLATES_PATH)

--- a/packages/react-static/templates/basic/package.json
+++ b/packages/react-static/templates/basic/package.json
@@ -13,7 +13,7 @@
     "axios": "^0.18.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "react-static": "^7.0.0",
+    "react-static": "^7.0.5",
     "react-static-plugin-reach-router": "^7.0.0",
     "react-static-plugin-sitemap": "^7.0.0",
     "react-static-plugin-source-filesystem": "^7.0.0"

--- a/packages/react-static/templates/blank/package.json
+++ b/packages/react-static/templates/blank/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "react-static": "^7.0.0",
+    "react-static": "^7.0.5",
     "react-static-plugin-reach-router": "^7.0.0",
     "react-static-plugin-sitemap": "^7.0.0",
     "react-static-plugin-source-filesystem": "^7.0.0"

--- a/packages/react-static/templates/stress-test/package.json
+++ b/packages/react-static/templates/stress-test/package.json
@@ -23,7 +23,7 @@
     "axios": "^0.18.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "react-static": "^7.0.0",
+    "react-static":"^7.0.5",
     "react-static-plugin-reach-router": "^7.0.0",
     "react-static-plugin-sitemap": "^7.0.0",
     "react-static-plugin-source-filesystem": "^7.0.0"

--- a/packages/react-static/templates/typescript/package.json
+++ b/packages/react-static/templates/typescript/package.json
@@ -14,7 +14,7 @@
     "axios": "^0.18.0",
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
-    "react-static": "^7.0.0",
+    "react-static": "^7.0.5",
     "react-static-plugin-reach-router": "^7.0.0",
     "react-static-plugin-sitemap": "^7.0.0",
     "react-static-plugin-source-filesystem": "^7.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
I installed a brand new basic template and CSS HMR was not working out of the box, then I realized that in `react-static@7.0.5` that problem was solved.
<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- Upgrade all templates react-static version to 7.0.5 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
CSS was not properly HMRing in 7.0.0, so a brand new instalation wouldn't work as intended
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
