### PR TITLE
Feature: upgrade extract-css-chunks-webpack-plugin to 4.3.0

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -57,7 +57,7 @@
     "cors": "^2.8.5",
     "css-loader": "^2.0.1",
     "download-git-repo": "^1.1.0",
-    "extract-css-chunks-webpack-plugin": "^4.0.2",
+    "extract-css-chunks-webpack-plugin": "^4.3.0",
     "file-loader": "2.0.0",
     "fs-extra": "^7.0.1",
     "git-promise": "^0.3.1",

--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -45,7 +45,15 @@ export default function({ stage, isNode }) {
     }
   }
 
-  cssLoader = [ExtractCssChunks.loader, ...cssLoader] // seeing as it's HMR, why not :)
+  cssLoader = [
+    {
+      loader: ExtractCssChunks.loader,
+      options: {
+        hot: true,
+      },
+    },
+    ...cssLoader,
+  ] // seeing as it's HMR, why not :)
 
   return {
     test: /\.css$/,

--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -67,7 +67,7 @@ export default function({ config }) {
       new webpack.HotModuleReplacementPlugin(),
       new webpack.NamedModulesPlugin(),
       new CaseSensitivePathsPlugin(),
-      new ExtractCssChunks({ hot: true }),
+      new ExtractCssChunks({ filename: '[name].css' }), // never hash dev code
       // new WebpackDashboard(),
     ],
     devtool: 'cheap-module-source-map',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5595,6 +5595,17 @@ extract-css-chunks-webpack-plugin@^4.0.2:
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 
+extract-css-chunks-webpack-plugin@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.3.0.tgz#01fb5ea225a78d5bd51e29b191dc1248ab320957"
+  integrity sha512-U2mCuqF9JKmyQydQQUy+tsCVCeuysgIZNZHd0eeTgIgq6gSqCnS9eaCpknyLVl3aRr8y2gkvRPzpuHS7AdvK0Q==
+  dependencies:
+    loader-utils "^1.1.0"
+    lodash "^4.17.11"
+    normalize-url "^2.0.1"
+    schema-utils "^1.0.0"
+    webpack-sources "^1.1.0"
+
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -9166,6 +9177,15 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
+normalize-url@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  integrity sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
 normalize-url@^3.0.0, normalize-url@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
@@ -10389,6 +10409,11 @@ prepend-http@^1.0.1:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=
 
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
+  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
 prettier@1.16.4:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
@@ -10607,6 +10632,15 @@ qs@6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+query-string@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -12092,6 +12126,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
HMR of CSS was not working for a fresh install of react-static 7.0.0 or 7.0.5, I tried upgrading extract-css-chunks-webpack-plugin to the 4.3.0 version (and it's corresponding webpack and css loaders modifications)

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->
- [x] `yarn add extract-css-chunks-webpack-plugin` in the packages/react-static folder
- [x] Changed the code in `webpack.config.dev.js` to match the extract-css-chunks API
- [x] Changed the code in `rules/cssLoader` to match the extract-css-chunks API

## Motivation and Context

This change is required because when you install a brand new app from `ǹpx react-static create` (using 7.0.5)  CSS files do not HMR (I think it's related with a bug with extract-css-chunks-webpack-plugin@4.0.2) and in my opinion this is among the best or almost esential features for any react project.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
