### PR TITLE
Fix afterPrepareRoutes hook

### DIFF
--- a/packages/react-static/src/static/getRoutes.js
+++ b/packages/react-static/src/static/getRoutes.js
@@ -58,7 +58,7 @@ export default async function getRoutes(state, callback = d => d) {
       routes: allNormalizedRoutes,
     }
 
-    return callback(plugins.afterPrepareRoutes(state))
+    return callback(await plugins.afterPrepareRoutes(state))
   }
 
   return rebuildRoutes.current()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
## Description
- start cmd calls getRoutes with callback
- cb gets fed promise by afterPrepareRoutes instead of state object
Solution: await afterPrepareRoutes before calling the cb

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

Bugfix

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
