### PR TITLE
chore: fix types

### DIFF
--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -15,9 +15,8 @@ declare module 'react-static' {
   type AnyReactComponent = ComponentType<Record<string, any>>
 
   // Passing on helmet typings as "Head"
-  import { Helmet } from 'react-helmet'
+  export { Helmet as Head } from 'react-helmet'
 
-  export class Head extends Helmet {}
   export class Routes extends React.Component<{ path: String }> {}
   export class Root extends React.Component {}
   export function useRouteData<T = any>(): T

--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -21,7 +21,7 @@ declare module 'react-static' {
   export class Routes extends React.Component<{ path: String }> {}
   export class Root extends React.Component {}
   export function useRouteData<T = any>(): T
-  export const useSiteData: object
+  export function useSiteData<T = any>(): T
   export function prefetch(path: any): Promise<any>
   export function addPrefetchExcludes(arg: String[]): void
   export const Prefetch: React.Component


### PR DESCRIPTION
I am developing a typescript react-static project and ran into the following issue while upgrading to v7 and using `useSiteData()` hook, which is blocking the build from compiling.

```
TS2349: Cannot invoke an expression whose type lacks a call signature. Type '{}' has no compatible call signatures.
``` 

## Description

I've changed `useSiteData` to the same signature as `useRouteData` which resolves the issue above. Additionally simplified the `react-helmet` types to a passive export.

## Changes/Tasks

- [x] Changed `useSiteData` type signature to fix the error
- [x] Removed the additional `Head` class and exported `{ Helmet as Head }` directly from `react-helmet`

## Motivation and Context

Fixes the error above that is currently blocking the app from compiling with `react-static` v7.0.6

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
