### PR TITLE
Fix Template Not Found error when reloading routes

### DIFF
--- a/packages/react-static/src/static/webpack/index.js
+++ b/packages/react-static/src/static/webpack/index.js
@@ -6,7 +6,7 @@ import WebpackDevServer from 'webpack-dev-server'
 import io from 'socket.io'
 //
 import { getStagedRules } from './rules'
-import { prepareRoutes, outputClientStats } from '../'
+import { prepareRoutes, outputClientStats, extractTemplates } from '../'
 import {
   getRoutePath,
   makeHookReducer,
@@ -250,6 +250,7 @@ export async function startDevServer({ config }) {
         paths = config.routes.map(route => route.path)
       }
       paths = paths.map(getRoutePath)
+      await extractTemplates(config, { dev: true })
       reloadWebpackRoutes(config)
       socket.emit('message', { type: 'reloadRoutes', paths })
     })


### PR DESCRIPTION
When `reloadRoutes` was called from the Node API, the rebuilt site had no template info returned from `/__react-static__/routeInfo/` calls. This was because routes were being rebuilt from the original config and previously loaded template data was lost. This change re-adds the template data on each call to `reloadRoutes`.

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Added `extractTemplates` call to `reloadRoutes`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
