### PR TITLE
react-static-plugin-reach-router: fix invalid peer dependency version

### DIFF
--- a/packages/react-static-plugin-reach-router/package.json
+++ b/packages/react-static-plugin-reach-router/package.json
@@ -15,7 +15,7 @@
     "preversion": "yarn build"
   },
   "peerDependencies": {
-    "@reach/router": "^0"
+    "@reach/router": "^1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.1.5",


### PR DESCRIPTION
## Description

Updated peerDependency version for Reach Router to be at least 1.0.0, rather than an invalid version number. 

## Changes/Tasks

- [x] Updated peerDependency version

## Motivation and Context

Yarn outputs `react-static-plugin-reach-router@7.0.0" has incorrect peer dependency "@reach/router@^0".` 

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)