### PR TITLE
Fix using custom config with CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 7.0.8
+
+### Improved
+
+- Fixed issues with custom config specified using `-c` or `-config` is not loaded
+
 # 7.0.7
 
 ### Improved

--- a/packages/react-static/bin/react-static
+++ b/packages/react-static/bin/react-static
@@ -19,7 +19,7 @@ function init() {
   const help = argv.help || argv.h || argv.H
   const options = {
     version: argv.version || argv.v || argv.V,
-    config: argv.config || argv.c || argv.C,
+    configPath: argv.config || argv.c || argv.C,
     name: argv.name || argv.n || argv.N,
     template: argv.template || argv.t || argv.T,
     staging: argv.staging || argv.s || argv.S,


### PR DESCRIPTION
Passing a `--config` argument to the CLI does not work in v7 due to a key mismatch between CLI bootstrapping and getConfig function.

## Description

Changed the key for config file path from `config` to `configPath` to match the use case in `getConfig.js`

## Changes/Tasks

## Motivation and Context

This fixes #1111

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them

## Notes:

This is my first contribution to react-static. Let me know how can I do better! :)