### PR TITLE
Remove invalid closing xml tag

### DIFF
--- a/packages/react-static-plugin-sitemap/src/buildXML.js
+++ b/packages/react-static-plugin-sitemap/src/buildXML.js
@@ -91,8 +91,7 @@ export function generateXML(
   return `<?xml version="1.0" encoding="UTF-8"?>
     <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     ${xmlRoutes}
-    </urlset>
-    </xml>`
+    </urlset>`
 }
 
 export function getPermaLink(path, prefixPath) {


### PR DESCRIPTION
## Description

React-static-plugin-sitemap generates sitemaps with an invalid </xml> tag, which causes the error below when attempting to view the document in-browser. 

## Changed code

Removed `</xml>` from line 95 of `buildXML.js`

## Screenshots (if appropriate):

Error: 
![image](https://user-images.githubusercontent.com/5226909/55927644-ae75fc00-5bca-11e9-862f-259a2b0857d9.png)

Generated Code:
![image](https://user-images.githubusercontent.com/5226909/55927835-4e338a00-5bcb-11e9-9095-1840029c61c0.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [X] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
