### PR TITLE
Update list of official plugins in the docs

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -12,14 +12,23 @@ React Static ships with a plugin API to extend React Static's functionality.
   - [react-static-plugin-sass](/packages/react-static-plugin-sass) - Adds SSR and general support for SASS
   - [react-static-plugin-less](/packages/react-static-plugin-less) - Adds SSR and general support for LESS
   - [react-static-plugin-jss](/packages/react-static-plugin-jss) - Adds SSR support for JSS
+  - [react-static-plugin-css-modules](/packages/react-static-plugin-css-modules) - Adds SSR support for CSS modules
 - React Alternatives
   - [react-static-plugin-preact](/packages/react-static-plugin-preact) - Adds preact support
 - Routing
   - [react-static-plugin-react-location](/packages/react-static-plugin-react-location) - Adds react-location support
   - [react-static-plugin-reach-router](/packages/react-static-plugin-reach-router) - Adds @reach/router support
   - [react-static-plugin-react-router](/packages/react-static-plugin-react-router) - Adds react-router support
+- Content
+  - [react-static-plugin-source-filesystem](/packages/react-static-plugin-source-filesystem) - Creates routes from files in a directory
+  - [react-static-plugin-mdx](/packages/react-static-plugin-mdx) - Adds support for MDX
 - Type checking
-  - [react-static-plugin-typescript](https://www.npmjs.com/package/react-static-plugin-typescript) - Allows you to write your components in TypeScript
+  - [react-static-plugin-typescript](packages/react-static-plugin-typescript) - Allows you to write your components in TypeScript
+- Assets
+  - [react-static-plugin-sitemap](packages/react-static-plugin-sitemap) - Exports sitemap information as XML
+  
+### Unofficial Plugins via NPM
+
 - Assets
   - [react-static-plugin-favicons](https://www.npmjs.com/package/react-static-plugin-favicons) - Generate (fav)icons in many different sizes for many different platforms, and add them to your site's metadata
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There were several newer plugins missing from the list in the docs, so I thought it'd be helpful to update it.

I did notice while updating the list that `react-static-plugin-favicons` is listed under 'official plugins', but actually seems to be maintained outside of the main React Static repo - this seemed a bit misleading, so I seperated it out. That said, this does raise the question of 'should this repo maintain a list of unofficial plugins?' - happy to make changes if you think the answer is no or if you want me to merge the lists back together!

## Changes/Tasks

* Added all official plugins to the list in the docs.
* Moved `react-static-plugin-favicons` to a seperate list of unofficial plugins.

## Motivation and Context

The main motivation for this was discoverability - I spent a little time trying to set up MDX for myself, only to realize there was already a plugin for it :p

## Types of changes

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes (*Do docs changes require a changelog entry? I will update it if so!*)
- [ ] My changes have tests around them (*N/A*)
