### PR TITLE
[v6] Handle undefined REACT_STATIC_PUBLIC_PATH in redirects

### DIFF
--- a/packages/react-static/src/static/components/Redirect.js
+++ b/packages/react-static/src/static/components/Redirect.js
@@ -4,21 +4,16 @@ import Head from 'react-helmet'
 
 export default class Redirect extends React.Component {
   render() {
+    const basePath = process.env.REACT_STATIC_PUBLIC_PATH || ''
     const { to, fromPath } = this.props
     let resolvedTo = typeof to === 'object' ? to.pathname : to
     if (!resolvedTo.includes('//')) {
-      resolvedTo = `${process.env.REACT_STATIC_PUBLIC_PATH}${
-        resolvedTo === '/' ? '' : resolvedTo
-      }`
+      resolvedTo = `${basePath}${resolvedTo === '/' ? '' : resolvedTo}`
     }
     return (
       <Head>
         {fromPath && (
-          <title>
-            {`${process.env.REACT_STATIC_PUBLIC_PATH}${
-              fromPath === '/' ? '' : fromPath
-            }`}
-          </title>
+          <title>{`${basePath}${fromPath === '/' ? '' : fromPath}`}</title>
         )}
         <link rel="canonical" href={resolvedTo} />
         <meta name="robots" content="noindex" />


### PR DESCRIPTION
Fixes a bug where redirects had `undefined` prepended to them when `REACT_STATIC_PUBLIC_PATH` env var was not set.

## Changes/Tasks

Added empty string fallback for env var in Redirect component.

- [x] Changed code

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
