### PR TITLE
Lambda Documentation wasn't working as it was

### DIFF
--- a/docs/guides/aws-lambda.md
+++ b/docs/guides/aws-lambda.md
@@ -6,6 +6,7 @@ As the Filesystem is _readonly_ in Serverless Environments we just have to confi
 
 ```javascript
 //static.config.js
+let os = require('os')
 const isBuild = process.env.NODE_ENV === 'production'
 
 let pathConfig = {}
@@ -16,6 +17,7 @@ if (isBuild) {
     dist: os.tmpdir() + '/dist',
     devDist: os.tmpdir() + '/dev-server',
     assets: os.tmpdir() + '/dist',
+    artifacts: os.tmpdir() + '/artifacts'
   }
 }
 
@@ -33,6 +35,7 @@ The most simple lambda function would look like this:
 //set the BABEL_CACHE_PATH as early as possible
 process.env.BABEL_CACHE_PATH = '/tmp/babel-cache.json'
 
+require('react-static/lib/utils/binHelper')
 const rs = require('react-static/lib/commands/build').default
 
 const handler = async (event, context) => {


### PR DESCRIPTION
Since the `static.config.js` file can be JSX, it was blowing up since the extra `binHelper` which is executed when in local, wasn't being executed in Lambda.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [ ] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
