### PR TITLE
Update documentation "reloadRoutes" -> "reloadClientData"

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ React-Static is packed with awesome components, hooks, and functions to help you
   - [prefetch](#prefetch-)
   - [addPrefetchExcludes](#addprefetchexcludes)
 - `react-static/node`
-  - [reloadRoutes](#reloadRoutes)
+  - [reloadClientData](#reloadClientData)
   - [makePageRoutes](#makePageRoutes)
   - [createSharedData](#createSharedData)
 
@@ -233,7 +233,7 @@ addPrefetchExcludes(['dynamic', /admin/i])
 
 The following functions are available as exports from the `react-static/node` module. They are a separate import so that they may be used **primarily** in your static.config.js and node.api.js plugin files.
 
-## `reloadRoutes`
+## `reloadClientData`
 
 Intended for use in your `static.config.js` during development. When called it will rebuild all of your routes and routeData by calling `config.getRoutes()` again. Any new routes or data returned will be hot-reloaded into your running development application. Its main use cases are very applicable if your routes or routeData are changing constantly during development and you do not want to restart the dev server. You can use this method to reload when local files are changed, update at a set timing interval, or even subscribe to an event stream from an API or CMS.
 
@@ -245,26 +245,26 @@ Example:
 
 ```javascript
 // static.config.js
-import { reloadRoutes } from 'react-static/node'
+import { reloadClientData } from 'react-static/node'
 
 // Reload Manually
-reloadRoutes()
+reloadClientData()
 
 // Reload when files change
 import chokidar from 'chokidar'
-chokidar.watch('./docs').on('all', () => reloadRoutes())
+chokidar.watch('./docs').on('all', () => reloadClientData())
 
 // Reload from API or CMS event
-YourFavoriteCMS.subscribe(reloadRoutes)
+YourFavoriteCMS.subscribe(reloadClientData)
 
 // Reload your routes every 10 seconds
-setInterval(reloadRoutes, 10 * 1000)
+setInterval(reloadClientData, 10 * 1000)
 
 // ETC!
 
 export default {
   getRoutes: () => {
-    // This will run each time `reloadRoutes` is called
+    // This will run each time `reloadClientData` is called
   },
 }
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,7 +35,7 @@ export default {
 }
 ```
 
-**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`reloadRoutes`](/docs/node-api.md/#reloadClientData)!**
+**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`reloadClientData`](/docs/api.md/#reloadClientData)!**
 
 ### `route`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,7 +35,7 @@ export default {
 }
 ```
 
-**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`reloadRoutes`](/docs/node-api.md/#reloadRoutes)!**
+**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`reloadRoutes`](/docs/node-api.md/#reloadClientData)!**
 
 ### `route`
 


### PR DESCRIPTION
## Description

Documentation mentioned `reloadRoutes` which appears to no longer be available in v7. https://github.com/nozzle/react-static/issues/985#issuecomment-478672421 recommends to use `reloadClientData`. 

## Changes/Tasks

- renamed `reloadRoutes` to `reloadClientData` in API.md
- renamed link in `config.md` from `node-api.md` to `api.md` and from `reloadRoutes` to `reloadClientData`

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
