### PR TITLE
Adds `afterBundle` hook to Plugin API

### DIFF
--- a/docs/plugins/node-api.md
+++ b/docs/plugins/node-api.md
@@ -230,6 +230,25 @@ export default pluginOptions => ({
 })
 ```
 
+## `afterBundle`
+
+After a completed bundle, run any asynchronous function.
+
+- Arguments:
+  - `state` - The current state of the CLI
+- Returns a new `state` object
+
+```javascript
+// node.api.js
+
+export default pluginOptions => ({
+  afterBundle: async state => {
+    // Use or alter the state of the CLI
+    return state
+  },
+})
+```
+
 ## `afterDevServerStart`
 
 Modify the `App` **component** before it is rendered to an element via `<App />`.

--- a/packages/react-static/src/static/plugins.js
+++ b/packages/react-static/src/static/plugins.js
@@ -9,6 +9,7 @@ const supportedHooks = [
   'normalizeRoute',
   'afterPrepareRoutes',
   'webpack',
+  'afterBundle',
   'afterDevServerStart',
   'beforeRenderToElement',
   'beforeRenderToHtml',
@@ -63,6 +64,10 @@ export default {
   webpack: (config, state) => {
     const hooks = getHooks(state.plugins, 'webpack')
     return reduceHooks(hooks, { sync: true })(config, state)
+  },
+  afterBundle: state => {
+    const hooks = getHooks(state.plugins, 'afterBundle')
+    return reduceHooks(hooks)(state)
   },
   afterDevServerStart: state => {
     const hooks = getHooks(state.plugins, 'afterDevServerStart')

--- a/packages/react-static/src/static/webpack/buildProductionBundles.js
+++ b/packages/react-static/src/static/webpack/buildProductionBundles.js
@@ -5,6 +5,7 @@ import chalk from 'chalk'
 import makeWebpackConfig from './makeWebpackConfig'
 import { outputClientStats } from '../clientStats'
 import { time, timeEnd } from '../../utils'
+import plugins from '../plugins'
 
 export default async function buildProductionBundles(state) {
   // Build static pages and JSON
@@ -73,6 +74,8 @@ export default async function buildProductionBundles(state) {
   })
 
   timeEnd(chalk.green('[\u2713] App Bundled'))
+
+  state = await plugins.afterBundle(state)
 
   return state
 }


### PR DESCRIPTION
## Description

Adds an `afterBundle` hook to the Plugin Node API 

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Run `plugins.afterBundle()` once `webpack/buildProductionBundles` is complete

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As discussed in #1158, I'm planning to copy the functionality of https://github.com/axe312ger/gatsby-plugin-netlify-cache into a React Static plugin, but also want to support a setup that may run `react-static bundle` and `react-static export` individually and perform some caching at the end of the bundle task

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
