### PR TITLE
use latest versions for typescript template

### DIFF
--- a/packages/react-static/templates/typescript/package.json
+++ b/packages/react-static/templates/typescript/package.json
@@ -15,10 +15,10 @@
     "react": "^16.8.2",
     "react-dom": "^16.8.2",
     "react-static": "^7.0.0",
-    "react-static-plugin-reach-router": "^7.0.0",
-    "react-static-plugin-sitemap": "^7.0.0",
-    "react-static-plugin-source-filesystem": "^7.0.0",
-    "react-static-plugin-typescript": "^7.0.0"
+    "react-static-plugin-reach-router": "latest",
+    "react-static-plugin-sitemap": "latest",
+    "react-static-plugin-source-filesystem": "latest",
+    "react-static-plugin-typescript": "latest"
   },
   "devDependencies": {
     "@types/node": "^10.12.23",

--- a/packages/react-static/templates/typescript/static.config.js
+++ b/packages/react-static/templates/typescript/static.config.js
@@ -5,7 +5,7 @@ import path from 'path'
 // Typescript support in static.config.js is not yet supported, but is coming in a future update!
 
 export default {
-  entry: 'index.tsx',
+  entry: path.join(__dirname, 'src', 'index.tsx'),
   getRoutes: async () => {
     const { data: posts } /* :{ data: Post[] } */ = await axios.get(
       'https://jsonplaceholder.typicode.com/posts'


### PR DESCRIPTION
## Description

`react-static create` somehow doesnt install latest patch versions of RS and this is bad for initial experience

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

an attempt to fix https://github.com/nozzle/react-static/issues/1163 for good - what do we think?


## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
