### PR TITLE
Fix docs reference to wrong function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@ React-Static is packed with awesome components, hooks, and functions to help you
   - [prefetch](#prefetch-)
   - [addPrefetchExcludes](#addprefetchexcludes)
 - `react-static/node`
-  - [reloadClientData](#reloadClientData)
+  - [rebuildRoutes](#rebuildRoutes)
   - [makePageRoutes](#makePageRoutes)
   - [createSharedData](#createSharedData)
 
@@ -233,7 +233,7 @@ addPrefetchExcludes(['dynamic', /admin/i])
 
 The following functions are available as exports from the `react-static/node` module. They are a separate import so that they may be used **primarily** in your static.config.js and node.api.js plugin files.
 
-## `reloadClientData`
+## `rebuildRoutes`
 
 Intended for use in your `static.config.js` during development. When called it will rebuild all of your routes and routeData by calling `config.getRoutes()` again. Any new routes or data returned will be hot-reloaded into your running development application. Its main use cases are very applicable if your routes or routeData are changing constantly during development and you do not want to restart the dev server. You can use this method to reload when local files are changed, update at a set timing interval, or even subscribe to an event stream from an API or CMS.
 
@@ -245,26 +245,26 @@ Example:
 
 ```javascript
 // static.config.js
-import { reloadClientData } from 'react-static/node'
+import { rebuildRoutes } from 'react-static/node'
 
 // Reload Manually
-reloadClientData()
+rebuildRoutes()
 
 // Reload when files change
 import chokidar from 'chokidar'
-chokidar.watch('./docs').on('all', () => reloadClientData())
+chokidar.watch('./docs').on('all', () => rebuildRoutes())
 
 // Reload from API or CMS event
-YourFavoriteCMS.subscribe(reloadClientData)
+YourFavoriteCMS.subscribe(rebuildRoutes)
 
 // Reload your routes every 10 seconds
-setInterval(reloadClientData, 10 * 1000)
+setInterval(rebuildRoutes, 10 * 1000)
 
 // ETC!
 
 export default {
   getRoutes: () => {
-    // This will run each time `reloadClientData` is called
+    // This will run each time `rebuildRoutes` is called
   },
 }
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -35,7 +35,7 @@ export default {
 }
 ```
 
-**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`reloadClientData`](/docs/api.md/#reloadClientData)!**
+**Awesome Tip: Changes made to `static.config.js` while the development server is running will automatically run `getRoutes` again and any changes to routes or routeData will be hot-reloaded instantly! Don't want to edit/resave your config file? Try using [`rebuildRoutes`](/docs/api.md/#rebuildRoutes)!**
 
 ### `route`
 


### PR DESCRIPTION
## Description

Revert https://github.com/nozzle/react-static/pull/1145, in which I not-fixed a reference to no-longer existing `reloadRoutes` by replacing it with `reloadClientData`, which exists but does something else. Point to correct function `rebuildRoutes`. Addresses #1144.

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
