### PR TITLE
Allow passing options to MDX webpack loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Improved
+
+- `react-static-plugin-mdx`: Allow passing MDX options to webpack loader (e.g. `remarkPlugins` and `rehypePlugins`)
+
 # 7.0.10
 
 ### Improved

--- a/packages/react-static-plugin-mdx/README.md
+++ b/packages/react-static-plugin-mdx/README.md
@@ -30,6 +30,10 @@ export default {
       {
         includePaths: ["..."], // Additional include paths on top of the default jsLoader paths
         extensions: ['.md', '.mdx'] // NOTE: these are the default extensions
+        mdxOptions: {
+          remarkPlugins: [/* ... */],
+          rehypePlugins: [/* ... */],
+        },
       }
     ]
   ]

--- a/packages/react-static-plugin-mdx/src/node.api.js
+++ b/packages/react-static-plugin-mdx/src/node.api.js
@@ -1,4 +1,8 @@
-export default ({ includePaths = [], extensions = ['.md', '.mdx'] }) => ({
+export default ({
+  includePaths = [],
+  extensions = ['.md', '.mdx'],
+  mdxOptions = {},
+}) => ({
   afterGetConfig: ({ config }) => {
     config.extensions = [...config.extensions, ...extensions]
   },
@@ -8,7 +12,13 @@ export default ({ includePaths = [], extensions = ['.md', '.mdx'] }) => ({
     webpackConfig.module.rules[0].oneOf.unshift({
       test: /.mdx?$/,
       include: [defaultLoaders.jsLoader.include, ...includePaths],
-      use: [defaultLoaders.jsLoader.use[0], mdxLoaderPath],
+      use: [
+        defaultLoaders.jsLoader.use[0],
+        {
+          loader: mdxLoaderPath,
+          options: mdxOptions,
+        },
+      ],
     })
 
     return webpackConfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

MDX has options like `remarkPlugins` and `rehypePlugins`, now it's possible to configure them through react-static-plugin-mdx as `mdxOptions`.

Let me know if you would like a different API!

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] add a new `mdxOptions` option to react-static-plugin-mdx
- [x] pass that as `options` to MDX webpack loader

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It makes it possible to configure MDX by adding [plugins](https://mdxjs.com/advanced/plugins).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them
