### PR TITLE
less plugin pointing to incorrect main file

### DIFF
--- a/packages/react-static-plugin-less/package.json
+++ b/packages/react-static-plugin-less/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-static-plugin-less",
   "version": "7.0.10",
-  "main": "index.js",
+  "main": "node.api.js",
   "license": "MIT",
   "scripts": {
     "build": "babel src --out-dir .",


### PR DESCRIPTION
`src` has a `node.api.js` file, not a `index.js` file, so `main` should be `node.api.js`.

The 7.0.10 npm install doesn't seem to have a compiled `node.api.js`, as there is only a copy in `src` and none in the root. This is probably the cause of this issue: https://github.com/nozzle/react-static/issues/1150

## Changes/Tasks

- [x] Update main in packages.json.

## Motivation and Context

Fix npm package.

https://github.com/nozzle/react-static/issues/1150

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
