### PR TITLE
Fix TypeScript definitions for Routes & add withRouteData & withSiteData

### DIFF
--- a/packages/react-static/src/index.d.ts
+++ b/packages/react-static/src/index.d.ts
@@ -17,10 +17,12 @@ declare module 'react-static' {
   // Passing on helmet typings as "Head"
   export { Helmet as Head } from 'react-helmet'
 
-  export class Routes extends React.Component<{ path: String }> {}
+  export class Routes extends React.Component<{ path?: String, default?: boolean }> {}
   export class Root extends React.Component {}
   export function useRouteData<T = any>(): T
   export function useSiteData<T = any>(): T
+  export function withRouteData(comp: any): any
+  export function withSiteData(comp: any): any
   export function prefetch(path: any): Promise<any>
   export function addPrefetchExcludes(arg: String[]): void
   export const Prefetch: React.Component


### PR DESCRIPTION
## Description
Updated `index.d.ts` so that you can compile the react-static typescript template when using specific parts of the API.

## Changes/Tasks

* Fixed invalid typescript definitions for Routes ( it's actually not for Routes but is rather hijacked by @reach/router, but that's just how it works it seems...).

* Added missing typescript definitions for `withRouteData` & `withSiteData`

- [x] Changed code

## Motivation and Context
Fix broken typescript definitions

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
