### PR TITLE
Allow react/react-dom submodules to work

### DIFF
--- a/packages/react-static/src/static/webpack/webpack.config.dev.js
+++ b/packages/react-static/src/static/webpack/webpack.config.dev.js
@@ -51,8 +51,8 @@ export default function({ config }) {
       ],
       extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],
       alias: {
-        react: resolveFrom(NODE_MODULES, 'react'),
-        'react-dom': resolveFrom(NODE_MODULES, 'react-dom'),
+        react$: resolveFrom(NODE_MODULES, 'react'),
+        'react-dom$': resolveFrom(NODE_MODULES, 'react-dom'),
         // This is here so HMR modules use the same emitter instance.
         // Likely this is only needed for locally linked dev on RS, but still...
         'webpack/hot/emitter': resolveFrom(__dirname, 'webpack/hot/emitter'),

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -125,8 +125,8 @@ function common(state) {
       ],
       extensions: ['.wasm', '.mjs', '.js', '.json', '.jsx'],
       alias: {
-        react: resolveFrom(config.paths.NODE_MODULES, 'react'),
-        'react-dom': resolveFrom(config.paths.NODE_MODULES, 'react-dom'),
+        react$: resolveFrom(config.paths.NODE_MODULES, 'react'),
+        'react-dom$': resolveFrom(config.paths.NODE_MODULES, 'react-dom'),
         'react-universal-component': resolveFrom(
           __dirname,
           'react-universal-component'


### PR DESCRIPTION
## Description

react-static is plagued by a problem that nextjs also suffered from. See https://github.com/jaredpalmer/after.js/issues/49 for example. Here is the commit that resolved the problem: https://github.com/zeit/next.js/pull/3731/files

## Changes/Tasks

- [x] Added dollar sign to react/react-dom alias like described in https://webpack.js.org/configuration/resolve/#resolvealias

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)