### PR TITLE
Please use non-0 exit status whenever CLI command fails

### DIFF
--- a/packages/react-static/bin/react-static
+++ b/packages/react-static/bin/react-static
@@ -2,7 +2,10 @@
 const path = require('path')
 //
 
-init()
+init().catch(e => {
+  console.trace(e)
+  process.exit(1)
+})
 
 function init() {
   const pkg = require('../package.json')


### PR DESCRIPTION
We had a bug in a react-static 7 app that was being deployed via CI. It went "blank" in our production environment because the CI pipeline didn't detect the failing build: The `react-static`-command exit status is still `0` whenever an error occurs while building...

This change should fix that.