### PR TITLE
Add createGetRoutes to source filesystem plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Improved
+
+- `react-static-plugin-source-filesystem`: You can now pass a new option `getRoutes` to create additional routes out of those found by the plugin. You can see an example in plugin's docs.
+
 # 7.0.10
 
 ### Improved

--- a/packages/react-static-plugin-source-filesystem/README.md
+++ b/packages/react-static-plugin-source-filesystem/README.md
@@ -19,9 +19,8 @@ $ yarn add react-static-plugin-source-filesystem
 Then add the plugin to your `static.config.js` with a valid `location` directory in the options:
 
 ```javascript
-...
 import path from 'path'
-...
+
 export default {
   plugins: [
     [
@@ -30,6 +29,60 @@ export default {
         location: path.resolve('./src/pages'),
       },
     ],
+  ],
+}
+```
+
+The plugin also supports several other options if you want to fine-tune your routes and create additional ones, e.g. for pagination:
+
+```javascript
+import { makePageRoutes } from 'react-static/node'
+import axios from 'axios'
+import path from 'path'
+
+export default {
+  plugins: [
+    'react-static-plugin-source-filesystem',
+    {
+      // required
+      location: path.resolve('./src/posts'),
+      // optional
+      pathPrefix: '/blog/posts',
+      createRoute: async ({ path, template, originalPath }) => ({
+        // our blog post file names start with a date,
+        // e.g. blog/posts/2018-10-03-hello-world
+        // so let's remove those to generate simpler paths
+        path: path.replace(/\d+-\d+-\d+-/, ''),
+        template,
+        originalPath,
+        getData: async () => {
+          const { joke } = await axios.get('https://icanhazdadjoke.com')
+          return {
+            dadJoke: joke,
+          }
+        },
+      }),
+      createGetRoutes: postRoutes => {
+        return async function getRoutes() {
+          return makePageRoutes({
+            items: postRoutes,
+            pageSize: 5,
+            pageToken: 'page',
+            route: {
+              path: '/blog',
+              template: 'src/pages/blog',
+            },
+            decorate: (items, pageIndex, totalPages) => ({
+              getData: () => ({
+                posts: items,
+                currentPage: pageIndex,
+                totalPages,
+              }),
+            }),
+          })
+        }
+      },
+    },
   ],
 }
 ```

--- a/packages/react-static-plugin-source-filesystem/src/node.api.js
+++ b/packages/react-static-plugin-source-filesystem/src/node.api.js
@@ -9,8 +9,10 @@ export default ({
   pathPrefix,
   createRoute = d => d,
   extensions = [],
+  createGetRoutes = () => async () => [],
 }) => ({
-  getRoutes: async (routes, state) => {
+  getRoutes: async (...getRoutesArgs) => {
+    const [routes, state] = getRoutesArgs
     const { config, stage, debug } = state
     if (!location) {
       throw new Error(
@@ -100,8 +102,10 @@ export default ({
 
     const pages = await glob(pagesGlob)
     const directoryRoutes = await handle(pages)
+    const getAdditionalRoutes = createGetRoutes(directoryRoutes)
+    const additionalRoutes = await getAdditionalRoutes(...getRoutesArgs)
 
-    return [...routes, ...directoryRoutes]
+    return [...routes, ...directoryRoutes, ...additionalRoutes]
   },
 })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This allows generating more routes based on existing ones. Useful for
tasks like pagination.

I also added documentation for `createRoute` in addition to
`createGetRoutes`.

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Add `createGetRoutes` to react-static-plugin-source-filesystem
- [x] Document `createRoute`
- [x] Document `createGetRoutes`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1170.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [x] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them