### PR TITLE
fix: HMR of real CSS files in development

### DIFF
--- a/packages/react-static-plugin-css-modules/package.json
+++ b/packages/react-static-plugin-css-modules/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "css-loader": "^2.0.1",
-    "extract-css-chunks-webpack-plugin": "^4.3.2"
+    "extract-css-chunks-webpack-plugin": "^4.5.1"
   },
   "gitHead": "ca9f2162257fe67a8b4ffcbb1350695345940da4"
 }

--- a/packages/react-static-plugin-css-modules/src/node.api.js
+++ b/packages/react-static-plugin-css-modules/src/node.api.js
@@ -4,7 +4,6 @@ export default (options = {}) => ({
   webpack: (config, { stage }) => {
     let loaders = []
 
-    const styleLoader = { loader: 'style-loader' }
     const cssLoader = {
       loader: 'css-loader',
       options: {
@@ -16,7 +15,16 @@ export default (options = {}) => ({
 
     if (stage === 'dev') {
       // Dev
-      loaders = [styleLoader, cssLoader]
+      loaders = [
+        {
+          loader: ExtractCssChunks.loader,
+          options: {
+            hot: true,
+            reloadAll: true,
+          },
+        },
+        cssLoader,
+      ]
     } else if (stage === 'node') {
       loaders = [
         {

--- a/packages/react-static-plugin-less/package.json
+++ b/packages/react-static-plugin-less/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "autoprefixer": "^9.5.1",
     "css-loader": "^2.1.0",
-    "extract-css-chunks-webpack-plugin": "^4.3.2",
+    "extract-css-chunks-webpack-plugin": "^4.5.1",
     "less": "^3.9.0",
     "less-loader": "^4.1.0",
     "postcss-flexbugs-fixes": "^4.1.0",

--- a/packages/react-static-plugin-less/src/node.api.js
+++ b/packages/react-static-plugin-less/src/node.api.js
@@ -12,7 +12,6 @@ export default ({ includePaths = [], ...rest }) => ({
       loader: lessLoaderPath,
       options: { includePaths: ['src/', ...includePaths], ...rest },
     }
-    const styleLoader = { loader: 'style-loader' }
     const cssLoader = {
       loader: 'css-loader',
       options: {
@@ -44,7 +43,17 @@ export default ({ includePaths = [], ...rest }) => ({
 
     if (stage === 'dev') {
       // Dev
-      loaders = [styleLoader, cssLoader, postCssLoader, lessLoader]
+      loaders = [
+        {
+          loader: ExtractCssChunks.loader,
+          options: {
+            hot: true,
+          },
+        },
+        cssLoader,
+        postCssLoader,
+        lessLoader,
+      ]
     } else if (stage === 'node') {
       // Node
       // Don't extract css to file during node build process

--- a/packages/react-static-plugin-sass/package.json
+++ b/packages/react-static-plugin-sass/package.json
@@ -20,7 +20,7 @@
     "@babel/preset-env": "^7.4.3"
   },
   "dependencies": {
-    "extract-css-chunks-webpack-plugin": "^4.3.2",
+    "extract-css-chunks-webpack-plugin": "^4.5.1",
     "node-sass": "^4.11.0",
     "sass-loader": "^7.1.0"
   },

--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -11,7 +11,6 @@ export default ({ includePaths = [], ...rest }) => ({
       loader: sassLoaderPath,
       options: { includePaths: ['src/', ...includePaths], ...rest },
     }
-    const styleLoader = { loader: 'style-loader' }
     const cssLoader = {
       loader: 'css-loader',
       options: {
@@ -22,7 +21,16 @@ export default ({ includePaths = [], ...rest }) => ({
 
     if (stage === 'dev') {
       // Dev
-      loaders = [styleLoader, cssLoader, sassLoader]
+      loaders = [
+        {
+          loader: ExtractCssChunks.loader,
+          options: {
+            hot: true,
+          },
+        },
+        cssLoader,
+        sassLoader,
+      ]
     } else if (stage === 'node') {
       // Node
       // Don't extract css to file during node build process

--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -56,7 +56,7 @@
     "cors": "^2.8.5",
     "css-loader": "^2.0.1",
     "download-git-repo": "^1.1.0",
-    "extract-css-chunks-webpack-plugin": "^4.3.2",
+    "extract-css-chunks-webpack-plugin": "^4.5.1",
     "file-loader": "3.0.1",
     "fs-extra": "^7.0.1",
     "git-promise": "^0.3.1",

--- a/packages/react-static/templates/blank/yarn.lock
+++ b/packages/react-static/templates/blank/yarn.lock
@@ -3645,13 +3645,12 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-css-chunks-webpack-plugin@^4.0.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.3.0.tgz#01fb5ea225a78d5bd51e29b191dc1248ab320957"
-  integrity sha512-U2mCuqF9JKmyQydQQUy+tsCVCeuysgIZNZHd0eeTgIgq6gSqCnS9eaCpknyLVl3aRr8y2gkvRPzpuHS7AdvK0Q==
+extract-css-chunks-webpack-plugin@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.5.1.tgz#b69be9d22297502ae55c77b5b8f2edf82fa47130"
+  integrity sha512-SMTguWPSE3nqLFhf9wVNbGg4LKSOolj2/C/WtWIKNDOh7Cc68leo/270N4HPCwwcnZs7zxw9zS+e5n1gynw1Gw==
   dependencies:
     loader-utils "^1.1.0"
-    lodash "^4.17.11"
     normalize-url "^2.0.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"

--- a/packages/react-static/templates/stress-test/yarn.lock
+++ b/packages/react-static/templates/stress-test/yarn.lock
@@ -3791,14 +3791,13 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-css-chunks-webpack-plugin@^3.2.1:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-3.3.3.tgz#d550be32b93dad5d290e9d979d37dd317bdaec9b"
-  integrity sha512-4DYo3jna9ov81rdKtE1U2cirb3ERoWhHldzRxZWx3Q5i5Dm6U+mmfon7PmaKDuh6+xySVOqtlXrZyJY2V4tc+g==
+extract-css-chunks-webpack-plugin@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.5.1.tgz#b69be9d22297502ae55c77b5b8f2edf82fa47130"
+  integrity sha512-SMTguWPSE3nqLFhf9wVNbGg4LKSOolj2/C/WtWIKNDOh7Cc68leo/270N4HPCwwcnZs7zxw9zS+e5n1gynw1Gw==
   dependencies:
     loader-utils "^1.1.0"
-    lodash "^4.17.11"
-    normalize-url "^3.3.0"
+    normalize-url "^2.0.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"
 

--- a/packages/react-static/templates/typescript/yarn.lock
+++ b/packages/react-static/templates/typescript/yarn.lock
@@ -3237,13 +3237,12 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-css-chunks-webpack-plugin@^4.0.2:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.3.0.tgz#01fb5ea225a78d5bd51e29b191dc1248ab320957"
-  integrity sha512-U2mCuqF9JKmyQydQQUy+tsCVCeuysgIZNZHd0eeTgIgq6gSqCnS9eaCpknyLVl3aRr8y2gkvRPzpuHS7AdvK0Q==
+extract-css-chunks-webpack-plugin@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.5.1.tgz#b69be9d22297502ae55c77b5b8f2edf82fa47130"
+  integrity sha512-SMTguWPSE3nqLFhf9wVNbGg4LKSOolj2/C/WtWIKNDOh7Cc68leo/270N4HPCwwcnZs7zxw9zS+e5n1gynw1Gw==
   dependencies:
     loader-utils "^1.1.0"
-    lodash "^4.17.11"
     normalize-url "^2.0.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6052,13 +6052,12 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-extract-css-chunks-webpack-plugin@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.3.2.tgz#dab841c62c53b50ce331eb2442f9d6f2fdc19f28"
-  integrity sha512-dTL4rwoMIwItq8KRhhgdHPcgFf7DwFRRcQBLj5F3k/WL2pSkYN//rS/dNUuRhbNgTMOV0HT60WjCVd9UGDaSOQ==
+extract-css-chunks-webpack-plugin@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-4.5.1.tgz#b69be9d22297502ae55c77b5b8f2edf82fa47130"
+  integrity sha512-SMTguWPSE3nqLFhf9wVNbGg4LKSOolj2/C/WtWIKNDOh7Cc68leo/270N4HPCwwcnZs7zxw9zS+e5n1gynw1Gw==
   dependencies:
     loader-utils "^1.1.0"
-    lodash "^4.17.11"
     normalize-url "^2.0.1"
     schema-utils "^1.0.0"
     webpack-sources "^1.1.0"


### PR DESCRIPTION
Its been a long and hard road. But HMR should now work reliably for any and all types of style content. Allowing users to reload real CSS files. No more style-loader needed

<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-adding extract-css-chunks HMR system back to react static development mode after joining forces with mini-css authors

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I get a staggering amount of emails from GitHub issues on react static. Id like less on the CSS subject


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them

fixes #1169 