### PR TITLE
Fix prefetch attribute

### DIFF
--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -153,7 +153,8 @@ function startPreloader() {
     els.forEach(el => {
       const href = el.getAttribute('href')
       const prefetchOption = el.getAttribute('data-prefetch')
-      const shouldPrefetch = !prefetchOption ||
+      const shouldPrefetch =
+        !prefetchOption ||
         prefetchOption === 'true' ||
         prefetchOption === 'visible'
 

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -153,7 +153,11 @@ function startPreloader() {
     els.forEach(el => {
       const href = el.getAttribute('href')
       const prefetchOption = el.getAttribute('data-prefetch')
-      const shouldPrefetch = !(!prefetchOption || prefetchOption === 'true' || prefetchOption === 'visible')
+      const shouldPrefetch = !(
+        !prefetchOption ||
+        prefetchOption === 'true' ||
+        prefetchOption === 'visible'
+      )
 
       if (href && shouldPrefetch) {
         onVisible(el, () => prefetch(href))

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -136,21 +136,32 @@ function init() {
   }
 }
 
+/**
+ * The preloader searches for all anchor elements on the page every poll
+ * interval, and, unless specified by data-prefetch, start a visibility observer
+ * for that element.
+ *
+ * The href of the anchor is preloaded when the element becomes visible.
+ */
 function startPreloader() {
-  if (typeof document !== 'undefined') {
-    const run = () => {
-      const els = [].slice.call(document.getElementsByTagName('a'))
-      els.forEach(el => {
-        const href = el.getAttribute('href')
-        const shouldPrefetch = !(el.getAttribute('prefetch') === 'false')
-        if (href && shouldPrefetch) {
-          onVisible(el, () => prefetch(href))
-        }
-      })
-    }
-
-    setInterval(run, Number(process.env.REACT_STATIC_PRELOAD_POLL_INTERVAL))
+  if (typeof document === 'undefined') {
+    return
   }
+  const run = () => {
+    const els = [].slice.call(document.getElementsByTagName('a'))
+
+    els.forEach(el => {
+      const href = el.getAttribute('href')
+      const prefetchOption = el.getAttribute('data-prefetch')
+      const shouldPrefetch = !(!prefetchOption || prefetchOption === 'true' || prefetchOption === 'visible')
+
+      if (href && shouldPrefetch) {
+        onVisible(el, () => prefetch(href))
+      }
+    })
+  }
+
+  setInterval(run, Number(process.env.REACT_STATIC_PRELOAD_POLL_INTERVAL))
 }
 
 async function reloadClientData() {

--- a/packages/react-static/src/browser/index.js
+++ b/packages/react-static/src/browser/index.js
@@ -153,11 +153,9 @@ function startPreloader() {
     els.forEach(el => {
       const href = el.getAttribute('href')
       const prefetchOption = el.getAttribute('data-prefetch')
-      const shouldPrefetch = !(
-        !prefetchOption ||
+      const shouldPrefetch = !prefetchOption ||
         prefetchOption === 'true' ||
         prefetchOption === 'visible'
-      )
 
       if (href && shouldPrefetch) {
         onVisible(el, () => prefetch(href))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The prefetch attribute is not an attribute on anchor elements. The preferred way to do custom attributes is using data-* attributes or custom web elements.

When using anchor attributes the only potential candidate would be rel="prefetch", but that is not enabled for anchor elements (only link elements):

https://developer.mozilla.org/en-US/docs/Web/HTTP/Link_prefetching_FAQ
## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [X] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This allows TypeScript or JavaScript over TypeScript (@ts-check // tsconfig.json allowJs: true) to correctly accept a data-prefetch override attribute. 

Additionally it limits the prefetching to:
- no attribute
- attribute value = `'true'`
- attribute value = `'visible'`

This allows for other components to add checks for other values such as `mount` (when it's found), `hover` (when it's hovered) or something different. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Breaks undocumented use of `prefetch`

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
