### PR TITLE
Don't strip trailing slashes of user-provided assetsPath / Append trailing slash to assetsPath, if necessary

### DIFF
--- a/packages/react-static/src/static/__tests__/getConfig.test.js
+++ b/packages/react-static/src/static/__tests__/getConfig.test.js
@@ -96,6 +96,43 @@ describe('buildConfig', () => {
 
     spyProcess.mockRestore()
   })
+
+  describe('assetsPath is correct', () => {
+    test('when no user-supplied assetsPath exists', () => {
+      const { config } = buildConfig({}, { assetsPath: undefined })
+
+      expect(config.assetsPath).toBe('')
+    })
+    test('when relative user-supplied assetsPath exists without trailing slash', () => {
+      const { config } = buildConfig({}, { assetsPath: '/relative-path' })
+
+      expect(config.assetsPath).toBe('/relative-path/')
+    })
+
+    test('when relative user-supplied assetsPath exists with trailing slash', () => {
+      const { config } = buildConfig({}, { assetsPath: '/relative-path/' })
+
+      expect(config.assetsPath).toBe('/relative-path/')
+    })
+
+    test('when absolute user-supplied assetsPath exists without trailing slash', () => {
+      const { config } = buildConfig(
+        {},
+        { assetsPath: 'https://example.com/assets' }
+      )
+
+      expect(config.assetsPath).toBe('https://example.com/assets/')
+    })
+
+    test('when absolute user-supplied assetsPath exists with trailing slash', () => {
+      const { config } = buildConfig(
+        {},
+        { assetsPath: 'https://example.com/assets/' }
+      )
+
+      expect(config.assetsPath).toBe('https://example.com/assets/')
+    })
+  })
 })
 
 describe('getConfig', () => {

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -136,6 +136,11 @@ export function buildConfig(state, config = {}) {
     assetsPath = `/${cleanSlashes(`${basePath}/${assetsPath}`)}/`
   }
 
+  // add trailing slash only if assetsPath was supplied, but no trailing slash
+  if (assetsPath !== '' && !assetsPath.endsWith('/')) {
+    assetsPath = `${assetsPath}/`
+  }
+
   // Add the project root as a plugin. This allows the dev
   // to use the plugin api directory in their project if they want
   const plugins = [...(config.plugins || []), paths.ROOT]

--- a/packages/react-static/src/static/getConfig.js
+++ b/packages/react-static/src/static/getConfig.js
@@ -131,7 +131,7 @@ export function buildConfig(state, config = {}) {
     basePath = cleanSlashes(config.basePath)
   }
   const publicPath = `${cleanSlashes(`${siteRoot}/${basePath}`)}/`
-  let assetsPath = cleanSlashes(config.assetsPath || paths.assets)
+  let assetsPath = config.assetsPath || paths.assets || ''
   if (assetsPath && !isAbsoluteUrl(assetsPath)) {
     assetsPath = `/${cleanSlashes(`${basePath}/${assetsPath}`)}/`
   }


### PR DESCRIPTION

## Description

This change stops the removing of trailing slashes in user-provided assetsPath (by ways of the `static.config.js`).


<!--- Describe your changes in detail -->

## Changes/Tasks

<!--- Add your changes or task as points (descriptions can be TL;DR) -->

- [x] Changed code

## Motivation and Context

Without this, when defining a custom assetPath, navigating is broken in development as well as in the production build of the affected site/project. This is due to the code-split template files of each page that cannot be loaded. Atleast that's what happened in our project after trying out the assetsPath setting.

Example:
User supplies `https://example.com/` as assetsPath.
In the built sites, assets now are loaded similar to this when navigating (note the missing slash after .com): `https://example.comsrc/container/example.js`

Note: Initial load of each page works, however when navigating, the main.js script fails to load the template js files of the page we want to navigate to.

For our project the fix seems to have worked and not broken anything else. I am pretty sure these changes don't break anything else, however I might not be experienced enough to know where else the assetsPath setting plays a role. Would be great if someone more knowledgeable with the code base could have a look.

I also created several tests around the `assetsPath` config setting, I hope these are in the right place.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [x] My changes have tests around them

This is my first pull request on GitHub, so I hope I did everything right 👍 