### PR TITLE
[v6] Handling undefined public path in sitemap

### DIFF
--- a/packages/react-static/src/static/buildXML.js
+++ b/packages/react-static/src/static/buildXML.js
@@ -49,7 +49,7 @@ export default async ({ config }) => {
   const { DIST } = paths
   const prefixPath = disableRoutePrefixing
     ? config.siteRoot
-    : process.env.REACT_STATIC_PUBLIC_PATH
+    : process.env.REACT_STATIC_PUBLIC_PATH || ''
 
   if (!config.siteRoot) {
     return


### PR DESCRIPTION
## Description

Follow up to #1137, for the sitemap builder.

## Changes/Tasks

Makes undefined `REACT_STATIC_PUBLIC_PATH` fall back to an empty string.

- [x] Changed code

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

<!--- If not delete the sub-heading above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Please put an `x` in all the following boxes that apply to these changes. -->

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
