### PR TITLE
[Reach Router] Add base path to server location URL

### DIFF
--- a/packages/react-static-plugin-reach-router/src/browser.api.js
+++ b/packages/react-static-plugin-reach-router/src/browser.api.js
@@ -23,7 +23,7 @@ export default ({ RouterProps: userRouterProps = {} }) => ({
 
     // If we're in SSR, use a manual server location
     return typeof document === 'undefined' ? (
-      <ServerLocation url={makePathAbsolute(staticInfo.path)}>
+      <ServerLocation url={makePathAbsolute(`${basepath}/${staticInfo.path}`)}>
         {renderedChildren}
       </ServerLocation>
     ) : (


### PR DESCRIPTION
Fixes https://github.com/nozzle/react-static/issues/1182 - where static export doesn't work when you set a `basePath` on your config.

## Description
Reach router (plugin) specifically makes the location URL absolute - meaning that given a `staticInfo.path` of `blog/post/79`, it'll transform it to `/blog/post/79` - which is outside of our app, hence rendering nothing. The `ServerLocation` lives outside of the main router, hence it needs to provide the full URL, with the base path.

## Changes/Tasks
- [x] Add `basepath` to `ServerLocation` URL.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
I haven't added any test, as I didn't see any in the Reach Router plugin. For the CHANGELOG summary, should I just add a section to it (there's no "unreleased" section) ?

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
