### PR TITLE
 Mention react-static-plugin-yandex-metrica in the plugins docs

### DIFF
--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -37,6 +37,7 @@ React Static ships with a plugin API to extend React Static's functionality.
 - Other
 
   - [react-static-plugin-google-tag-manager](https://www.npmjs.com/package/react-static-plugin-google-tag-manager) - Easily add the GTM script tag to your HTML files
+  - [react-static-plugin-yandex-metrica](https://www.npmjs.com/package/react-static-plugin-yandex-metrica) - Add the [Yandex Metrica](https://metrica.yandex.com/about) script tag
 
 ### Local Plugins via the `/plugins` directory
 


### PR DESCRIPTION
I'm adding a link to the Yandex Metrica plugin in the plugins docs.

## Checklist:

- [x] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
