### PR TITLE
Use contenthash over hash for deterministic hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `react-static-plugin-stylus` A plugin for using stylus
 - Added a styled-components guide
 - Added `react-static-plugin-google-tag-manager` to the list of 3rd party plugins
+- `react-static`: Use `contenthash` over `hash` in output filename for deterministic filenames
 
 ### Improved
 

--- a/packages/react-static/src/static/webpack/webpack.config.prod.js
+++ b/packages/react-static/src/static/webpack/webpack.config.prod.js
@@ -77,7 +77,7 @@ function common(state) {
           require.resolve('../../bootstrapApp'),
         ],
     output: {
-      filename: '[name].[hash:8].js', // dont use chunkhash, its not a chunk
+      filename: '[name].[contenthash:8].js', // dont use chunkhash, its not a chunk
       chunkFilename: 'templates/[name].[chunkHash:8].js',
       path: ASSETS,
       publicPath: process.env.REACT_STATIC_ASSETS_PATH || '/',


### PR DESCRIPTION
## Description
According to Webpack documentation, `hash` is unique per build. When building on multiple machines, this hash is different on all builds. Using `contenthash` ensure we get deterministic hashes between multiple machines.
https://webpack.js.org/configuration/output/#outputfilename

Webpack also recommend using `contenthash` for long term caching.
https://webpack.js.org/guides/caching/#output-filenames

This is fixable in "user-land" by updating their Webpack config, we've done so like below for now, but I think this would be nice to work out-of-the-box.

```js
// node.api.js
export default () => ({
  webpack: (config, { defaultloaders }) => {
    if (config.output.filename !== 'static-app.js') {
      config.output.filename = '[name].[contenthash:8].js'
    }

    return config
  }
}) 
```

## Changes/Tasks
- [x] Update `config.output.filename` to use `contenthash` over `hash`

## Motivation and Context
We are currently transitioning from a monolith Rails application to a static site and during this transition, we are building a React Static site at deploy time. Each server in our load balancer builds the same React Static application and should be able to serve it. When a request is made for a page, the markup could be served from one server while assets get's served from another. With non-deterministic hashes, we end up with a bunch of 404's.

## Types of changes
- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] I have updated the documentation accordingly
- [x] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them