### PR TITLE
tweak startup perf by JSON.parse routeInfo

### DIFF
--- a/packages/react-static/package.json
+++ b/packages/react-static/package.json
@@ -66,6 +66,7 @@
     "inquirer": "^6.3.1",
     "inquirer-autocomplete-prompt": "^1.0.1",
     "intersection-observer": "^0.5.1",
+    "jsesc" : "^2.5.2",
     "match-sorter": "^3.0.0",
     "minimist": "^1.2.0",
     "mutation-observer": "^1.0.3",

--- a/packages/react-static/src/static/components/BodyWithMeta.js
+++ b/packages/react-static/src/static/components/BodyWithMeta.js
@@ -1,14 +1,14 @@
 import React from 'react'
 import { pathJoin, makePathAbsolute } from '../../utils'
-
-const REGEX_FOR_SCRIPT = /<(\/)?(script)/gi
+import jsesc from 'jsesc';
 
 const generateRouteInformation = embeddedRouteInfo => ({
   __html: `
-    window.__routeInfo = ${JSON.stringify(embeddedRouteInfo).replace(
-      REGEX_FOR_SCRIPT,
-      '<"+"$1$2'
-    )};`,
+    window.__routeInfo = JSON.parse(${jsesc(JSON.stringify(embeddedRouteInfo), {
+      isScriptContext: true,
+      wrap: true,
+      json: true
+    })});`,
 })
 
 // Not only do we pass react-helmet attributes and the app.js here, but


### PR DESCRIPTION
see https://twitter.com/HenrikJoreteg/status/1143953338284703744

## Description

routeInfo is passed as json string and evaluated as JSON at runtime (which should increase the startup performance)

## Changes/Tasks

- [x] Changed code

## Motivation and Context

performance is always an issue ;)

## Types of changes

- [ ] Refactoring/add tests (refactoring or adding test which isn't a fix or add a feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have updated the documentation accordingly
- [ ] I have updated the CHANGELOG with a summary of my changes
- [ ] My changes have tests around them
