### PR TITLE
Prevent FOUC in sass plugin

### DIFF
--- a/packages/react-static-plugin-sass/src/node.api.js
+++ b/packages/react-static-plugin-sass/src/node.api.js
@@ -75,6 +75,10 @@ export default ({ includePaths = [], ...rest }) => ({
       use: loaders,
     })
 
+    if (config.optimization.splitChunks.cacheGroups.styles) {
+      config.optimization.splitChunks.cacheGroups.styles.test = /\.(c|sc|sa)ss$/
+    }
+
     return config
   },
 })


### PR DESCRIPTION
When using the Sass plugin, a Flash Of Unstyled Content may appear in a built application.

This seems be caused by the missing configuration of Webpack's [Split Chunk Optimization](https://webpack.js.org/plugins/split-chunks-plugin) when using this plugin. 

The default CSS loader loads all CSS in a single chunk by default (when the `extractCssChunks` configuration option isn't set) [See this related source code](https://github.com/nozzle/react-static/blob/master/packages/react-static/src/static/webpack/webpack.config.prod.js#L55), but the SASS module is missing this configuration / is not not patching up the related configuration.

This PR should fix that and fixes issue #1177.
