### PR TITLE
cssloader: Rename "browsers" to "overrideBrowserslist"

### DIFF
--- a/packages/react-static/src/static/webpack/rules/cssLoader.js
+++ b/packages/react-static/src/static/webpack/rules/cssLoader.js
@@ -21,7 +21,7 @@ function initCSSLoader() {
         plugins: () => [
           postcssFlexbugsFixes,
           autoprefixer({
-            browsers: [
+            overrideBrowserslist: [
               '>1%',
               'last 4 versions',
               'Firefox ESR',


### PR DESCRIPTION
Running `react-static` currently prints this warning:

```
Replace Autoprefixer browsers option to Browserslist config.
Use browserslist key in package.json or .browserslistrc file.

Using browsers option cause some error. Browserslist config
can be used for Babel, Autoprefixer, postcss-normalize and other tools.

If you really need to use option, rename it to overrideBrowserslist.

Learn more at:
https://github.com/browserslist/browserslist#readme
https://twitter.com/browserslist
```

It goes away by renaming `browsers` to `overrideBrowserslist` as
suggested.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
